### PR TITLE
Design: product icon exploration page and icon family docs

### DIFF
--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -97,20 +97,22 @@ function SpaceV1({ size = 40 }) {
   )
 }
 
-/* ── FLOW: Three parallel curves flowing lower-left to upper-right ──
-   No CSS rotation. Curves positioned naturally diagonal in the viewBox.
-   Matches the hex accent direction. Each line has a dot at the end. */
+/* ── FLOW: Branching design from v2 (the one you approved) + 45deg rotation ── */
 function FlowV3({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* Three parallel Q-curves, lower-left to upper-right */}
-      <path d="M2 32 Q16 18 30 24" fill="none" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
-      <path d="M8 28 Q22 10 36 16" fill="none" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b2" />
-      <path d="M14 36 Q28 22 38 26" fill="none" stroke="#6B9AEA" strokeWidth="1.5" strokeLinecap="round" className="fl-line fl-b3" />
-      {/* Endpoint dots at the end of each curve */}
-      <circle cx="30" cy="24" r="3.5" fill="#6B9AEA" className="fl-out fl-out1" />
-      <circle cx="36" cy="16" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
-      <circle cx="38" cy="26" r="3.5" fill="#6B9AEA" className="fl-out fl-out3" />
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" style={{ transform: 'rotate(-45deg)' }}>
+      {/* Input dot */}
+      <circle cx="6" cy="20" r="4" fill="#3B7BF2" className="fl-src" />
+      {/* Trunk line */}
+      <path d="M10 20H18" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b1" />
+      {/* Three Q-curve branches splitting from junction */}
+      <path d="M18 20Q22 20 26 12" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
+      <path d="M18 20Q22 20 26 20" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
+      <path d="M18 20Q22 20 26 28" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" fill="none" className="fl-line fl-b3" />
+      {/* Output dots */}
+      <circle cx="30" cy="12" r="3" fill="#6B9AEA" className="fl-out fl-out1" />
+      <circle cx="30" cy="20" r="3" fill="#3B7BF2" className="fl-out fl-out2" />
+      <circle cx="30" cy="28" r="3" fill="#6B9AEA" className="fl-out fl-out3" />
     </svg>
   )
 }

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -242,12 +242,15 @@ function HexFlow({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      <path d="M422 195 Q440 175 460 185" fill="none" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
-      <path d="M432 185 Q450 165 470 175" fill="none" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b2" />
-      <path d="M442 195 Q460 178 480 185" fill="none" stroke="#6B9AEA" strokeWidth="1.5" strokeLinecap="round" className="fl-line fl-b3" />
-      <circle cx="422" cy="195" r="3.5" fill="#6B9AEA" className="fl-out fl-out1" />
-      <circle cx="450" cy="173" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
-      <circle cx="480" cy="185" r="3.5" fill="#6B9AEA" className="fl-out fl-out3" />
+      {/* Branching design: input dot, trunk, three Q-curve branches */}
+      <circle cx="425" cy="190" r="5" fill="#3B7BF2" className="fl-src" />
+      <path d="M430 190H445" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
+      <path d="M445 190Q455 190 465 175" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
+      <path d="M445 190Q455 190 468 190" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
+      <path d="M445 190Q455 190 465 205" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b3" />
+      <circle cx="470" cy="175" r="4" fill="#6B9AEA" className="fl-out fl-out1" />
+      <circle cx="473" cy="190" r="4" fill="#3B7BF2" className="fl-out fl-out2" />
+      <circle cx="470" cy="205" r="4" fill="#6B9AEA" className="fl-out fl-out3" />
     </svg>
   )
 }

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -97,24 +97,20 @@ function SpaceV1({ size = 40 }) {
   )
 }
 
-/* ── FLOW: Git-branch style with Q curves, rotated 45deg ──
-   Same layout as the v2 design you liked: input dot on left, horizontal trunk,
-   three curved branches (Q bezier) splitting to upper/middle/lower outputs. */
+/* ── FLOW: Three parallel curved lines with dots (matches hex accent exactly) ──
+   Same curves as ProductLogos.jsx FlowLogo, scaled to 40x40, rotated 45deg.
+   Data travels along the curves from start dots to end dots. */
 function FlowV3({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none" style={{ transform: 'rotate(-45deg)' }}>
-      {/* Input dot */}
-      <circle cx="6" cy="20" r="4" fill="#3B7BF2" className="fl-src" />
-      {/* Trunk */}
-      <path d="M10 20H18" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b1" />
-      {/* Curved branches (Q = quadratic bezier, like git branch) */}
-      <path d="M18 20Q22 20 26 12" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
-      <path d="M18 20Q22 20 26 20" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
-      <path d="M18 20Q22 20 26 28" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" fill="none" className="fl-line fl-b3" />
-      {/* Output dots */}
-      <circle cx="30" cy="12" r="3" fill="#6B9AEA" className="fl-out fl-out1" />
-      <circle cx="30" cy="20" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
-      <circle cx="30" cy="28" r="3" fill="#6B9AEA" className="fl-out fl-out3" />
+      {/* Three parallel Q-curves flowing upper-right (same shape as hex accent) */}
+      <path d="M4 28 Q14 14 26 20" fill="none" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
+      <path d="M10 24 Q20 10 32 16" fill="none" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b2" />
+      <path d="M16 28 Q26 16 38 20" fill="none" stroke="#6B9AEA" strokeWidth="1.5" strokeLinecap="round" className="fl-line fl-b3" />
+      {/* Endpoint dots */}
+      <circle cx="26" cy="20" r="3.5" fill="#6B9AEA" className="fl-out fl-out1" />
+      <circle cx="32" cy="16" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
+      <circle cx="38" cy="20" r="3.5" fill="#6B9AEA" className="fl-out fl-out3" />
     </svg>
   )
 }

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -97,18 +97,24 @@ function SpaceV1({ size = 40 }) {
   )
 }
 
-/* ── FLOW: Curved branches like git-branch, rotated 45deg ── */
+/* ── FLOW: Git-branch style with Q curves, rotated 45deg ──
+   Same layout as the v2 design you liked: input dot on left, horizontal trunk,
+   three curved branches (Q bezier) splitting to upper/middle/lower outputs. */
 function FlowV3({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none" style={{ transform: 'rotate(-45deg)' }}>
-      {/* Three curved flow lines (Q = quadratic bezier, like the original hex) */}
-      <path d="M4 30 Q14 10 24 18" fill="none" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
-      <path d="M10 28 Q20 12 32 16" fill="none" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b2" />
-      <path d="M16 32 Q26 18 36 22" fill="none" stroke="#6B9AEA" strokeWidth="1.5" strokeLinecap="round" className="fl-line fl-b3" />
-      {/* Endpoint dots */}
-      <circle cx="4" cy="30" r="3.5" fill="#6B9AEA" className="fl-out fl-out1" />
-      <circle cx="24" cy="18" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
-      <circle cx="36" cy="22" r="3.5" fill="#6B9AEA" className="fl-out fl-out3" />
+      {/* Input dot */}
+      <circle cx="6" cy="20" r="4" fill="#3B7BF2" className="fl-src" />
+      {/* Trunk */}
+      <path d="M10 20H18" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b1" />
+      {/* Curved branches (Q = quadratic bezier, like git branch) */}
+      <path d="M18 20Q22 20 26 12" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
+      <path d="M18 20Q22 20 26 20" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
+      <path d="M18 20Q22 20 26 28" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" fill="none" className="fl-line fl-b3" />
+      {/* Output dots */}
+      <circle cx="30" cy="12" r="3" fill="#6B9AEA" className="fl-out fl-out1" />
+      <circle cx="30" cy="20" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
+      <circle cx="30" cy="28" r="3" fill="#6B9AEA" className="fl-out fl-out3" />
     </svg>
   )
 }

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -242,16 +242,16 @@ function HexFlow({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      {/* Branching design tilted ~30deg to match hex gap angle */}
-      <g transform="rotate(-25, 450, 185)">
+      {/* Branching design tilted ~25deg, pushed outside hex opening */}
+      <g transform="rotate(-25, 460, 180) translate(15, -10)">
         <circle cx="425" cy="190" r="5" fill="#3B7BF2" className="fl-src" />
-        <path d="M430 190H445" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
-        <path d="M445 190Q455 190 465 175" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
-        <path d="M445 190Q455 190 468 190" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
-        <path d="M445 190Q455 190 465 205" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b3" />
-        <circle cx="470" cy="175" r="4" fill="#6B9AEA" className="fl-out fl-out1" />
-        <circle cx="473" cy="190" r="4" fill="#3B7BF2" className="fl-out fl-out2" />
-        <circle cx="470" cy="205" r="4" fill="#6B9AEA" className="fl-out fl-out3" />
+        <path d="M430 190H448" stroke="#6B9AEA" strokeWidth="3.5" strokeLinecap="round" className="fl-line fl-b1" />
+        <path d="M448 190Q458 190 470 173" stroke="#6B9AEA" strokeWidth="3.5" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
+        <path d="M448 190Q458 190 472 190" stroke="#6B9AEA" strokeWidth="3.5" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
+        <path d="M448 190Q458 190 470 207" stroke="#6B9AEA" strokeWidth="3.5" strokeLinecap="round" fill="none" className="fl-line fl-b3" />
+        <circle cx="474" cy="173" r="5" fill="#6B9AEA" className="fl-out fl-out1" />
+        <circle cx="477" cy="190" r="5" fill="#3B7BF2" className="fl-out fl-out2" />
+        <circle cx="474" cy="207" r="5" fill="#6B9AEA" className="fl-out fl-out3" />
       </g>
     </svg>
   )

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -3,13 +3,21 @@
 import { AnimatedSection } from '@/components/ui/AnimatedSection'
 import { Badge } from '@/components/ui/Badge'
 import { HexContainer } from '@/components/ui/Logo'
+import Logo from '@/components/ui/Logo'
 
 /* ═══════════════════════════════════════════════════
-   PRODUCT ICON EXPLORATION v3
-   - Unified brand blue (#3B7BF2 / #6B9AEA / #2D6AE0)
-   - 10s heartbeat cycle (burst first 10%, rest 90%)
-   - Animations match original hex accent quality
+   PRODUCT ICON EXPLORATION v4
+   RULES:
+   - All icons visible at rest (min opacity 0.3-0.55, never 0)
+   - Unified brand blue: #3B7BF2, #6B9AEA, #2D6AE0
+   - 10s heartbeat cycle (burst 0-10%, rest 10-100%)
+   - Hex versions match original HTML exactly
 ═══════════════════════════════════════════════════ */
+
+/* ── JOTIL LABS (parent brand) ── */
+function JotilLabsLogo({ size = 80 }) {
+  return <Logo size={size} />
+}
 
 /* ── RECEPTIONIST: Waveform bars ── */
 function ReceptionistV1({ size = 40 }) {
@@ -49,7 +57,7 @@ function ReceptionistV3({ size = 40 }) {
   )
 }
 
-/* ── MESSENGER: Three dots scale pulse (PICKED) ── */
+/* ── MESSENGER: Three FILLED dots (PICKED) ── */
 function MessengerV2({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
@@ -60,62 +68,59 @@ function MessengerV2({ size = 40 }) {
   )
 }
 
-/* ── OUTREACH: Paper plane with flight trajectory (PICKED) ── */
+/* ── OUTREACH: Paper plane, ALWAYS visible, animates on burst ── */
 function OutreachV1({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      {/* Static base plane always visible */}
+      <path d="M26 16L8 14l8 10-2 10z" fill="#3B7BF2" opacity="0.25" />
+      {/* Animated planes that fly out */}
       <g className="pp pp1">
         <path d="M26 16L8 14l8 10-2 10z" fill="#3B7BF2" />
       </g>
       <g className="pp pp2">
         <path d="M26 16L8 14l8 10-2 10z" fill="#3B7BF2" />
       </g>
-      <g className="pp pp3">
-        <path d="M26 16L8 14l8 10-2 10z" fill="#3B7BF2" />
-      </g>
     </svg>
   )
 }
 
-/* ── SPACE: Shape carousel, one at a time (PICKED) ── */
+/* ── SPACE: 4 shapes grid, each morphs/pulses in place (not carousel) ── */
 function SpaceV1({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="20" cy="20" r="8" fill="#3B7BF2" className="cs cs-circle" />
-      <polygon points="20,12 28,20 20,28 12,20" fill="#3B7BF2" className="cs cs-diamond" />
-      <polygon points="20,12 28,28 12,28" fill="#3B7BF2" className="cs cs-triangle" />
-      <rect x="12" y="12" width="16" height="16" rx="2" fill="#3B7BF2" className="cs cs-square" />
+      <circle cx="12" cy="12" r="6" fill="#3B7BF2" className="sp sp1" />
+      <rect x="22" y="6" width="12" height="12" rx="2" fill="#3B7BF2" className="sp sp2" />
+      <polygon points="12,28 18,40 6,40" fill="#3B7BF2" className="sp sp3" />
+      <polygon points="28,26 34,32 28,38 22,32" fill="#3B7BF2" className="sp sp4" />
     </svg>
   )
 }
 
-/* ── FLOW: Branching with data flowing from input to outputs (PICKED) ──
-   Aligned diagonally (parallel to hex gap), dot travels from source to targets */
+/* ── FLOW: Horizontal branch, rotated 45deg, data travels from input to outputs ── */
 function FlowV3({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* Static structure: branches */}
-      <path d="M8 28L18 20" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl1" />
-      <path d="M18 20L32 10" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl2" />
-      <path d="M18 20L32 20" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl2" />
-      <path d="M18 20L32 30" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl3" />
-      {/* Source dot */}
-      <circle cx="8" cy="28" r="4" fill="#3B7BF2" className="fl-src" />
-      {/* Junction dot */}
-      <circle cx="18" cy="20" r="3" fill="#6B9AEA" className="fl-junc" />
-      {/* Target dots */}
-      <circle cx="32" cy="10" r="3" fill="#6B9AEA" className="fl-out fl-out1" />
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" style={{ transform: 'rotate(-45deg)' }}>
+      {/* Input dot */}
+      <circle cx="6" cy="20" r="4" fill="#3B7BF2" className="fl-src" />
+      {/* Main line */}
+      <path d="M10 20H18" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line" />
+      {/* Branches */}
+      <path d="M18 20L30 12" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b1" />
+      <path d="M18 20L30 20" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b2" />
+      <path d="M18 20L30 28" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b3" />
+      {/* Output dots - always visible at baseline */}
+      <circle cx="32" cy="12" r="3" fill="#6B9AEA" className="fl-out fl-out1" />
       <circle cx="32" cy="20" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
-      <circle cx="32" cy="30" r="3" fill="#6B9AEA" className="fl-out fl-out3" />
-      {/* Traveling data packet */}
-      <circle cx="8" cy="28" r="2" fill="#2D6AE0" className="fl-packet" />
+      <circle cx="32" cy="28" r="3" fill="#6B9AEA" className="fl-out fl-out3" />
+      {/* Traveling packet */}
+      <circle r="2" fill="#2D6AE0" className="fl-packet" />
     </svg>
   )
 }
 
-/* ── AVATAR: New variations ── */
+/* ── AVATAR variations ── */
 function AvatarV1({ size = 40 }) {
-  // Pulsing concentric rings + face (incoming video call)
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
       <circle cx="20" cy="18" r="17" stroke="#6B9AEA" strokeWidth="1" fill="none" className="av-ring av-ring1" />
@@ -130,14 +135,12 @@ function AvatarV1({ size = 40 }) {
 }
 
 function AvatarV2({ size = 40 }) {
-  // Face with speaking waveform below (AI that talks face to face)
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
       <circle cx="20" cy="14" r="8" fill="#3B7BF2" opacity="0.06" stroke="#3B7BF2" strokeWidth="1.2" />
       <circle cx="17.5" cy="12.5" r="1.3" fill="#3B7BF2" />
       <circle cx="22.5" cy="12.5" r="1.3" fill="#3B7BF2" />
       <path d="M17 17Q20 20 23 17" stroke="#3B7BF2" strokeWidth="1.3" strokeLinecap="round" fill="none" />
-      {/* Speaking waveform */}
       <rect x="10" y="28" width="2.5" height="6" rx="1.25" fill="#6B9AEA" className="vb vb1" />
       <rect x="15" y="26" width="2.5" height="10" rx="1.25" fill="#6B9AEA" className="vb vb2" />
       <rect x="20" y="25" width="2.5" height="12" rx="1.25" fill="#6B9AEA" className="vb vb3" />
@@ -148,14 +151,10 @@ function AvatarV2({ size = 40 }) {
 }
 
 function AvatarV3({ size = 40 }) {
-  // Ascending dots (like parent brand) but with a face formed by the top dot
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* Body circle (largest, bottom) */}
       <circle cx="20" cy="30" r="8" fill="#3B7BF2" opacity="0.08" stroke="#6B9AEA" strokeWidth="1.5" className="hb hb1" />
-      {/* Torso (medium) */}
       <circle cx="20" cy="19" r="5" fill="#3B7BF2" opacity="0.1" stroke="#6B9AEA" strokeWidth="1.5" className="hb hb2" />
-      {/* Head (smallest, top) with face */}
       <circle cx="20" cy="10" r="6" fill="#3B7BF2" opacity="0.06" stroke="#3B7BF2" strokeWidth="1.5" className="hb hb3" />
       <circle cx="18" cy="9" r="1" fill="#3B7BF2" />
       <circle cx="22" cy="9" r="1" fill="#3B7BF2" />
@@ -165,7 +164,6 @@ function AvatarV3({ size = 40 }) {
 }
 
 function AvatarV4({ size = 40 }) {
-  // Video screen frame with face + live indicator
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
       <rect x="4" y="6" width="32" height="22" rx="4" stroke="#6B9AEA" strokeWidth="1.5" fill="#3B7BF2" opacity="0.04" />
@@ -173,15 +171,24 @@ function AvatarV4({ size = 40 }) {
       <circle cx="18.5" cy="13" r="1" fill="#3B7BF2" />
       <circle cx="21.5" cy="13" r="1" fill="#3B7BF2" />
       <path d="M18 16.5Q20 18.5 22 16.5" stroke="#3B7BF2" strokeWidth="1" strokeLinecap="round" fill="none" />
-      {/* Live dot */}
       <circle cx="32" cy="10" r="2" fill="#2D6AE0" className="av-live" />
-      {/* Bottom bar (call controls hint) */}
       <rect x="12" y="32" width="16" height="3" rx="1.5" fill="#6B9AEA" opacity="0.3" />
     </svg>
   )
 }
 
 /* ── HEX VERSIONS ── */
+function HexJotilLabs({ size = 80 }) {
+  return (
+    <svg width={size} height={size} viewBox="220 130 320 280">
+      <HexContainer />
+      <g className="hb hb1" fill="#3B7BF2"><path d="M424.23 202.37 c-2.05 -1.83 -2.42 -2.64 -2.42 -5.42 0 -4.18 2.05 -7.11 5.94 -8.50 2.57 -0.88 3.22 -0.88 5.57 0.22 3.37 1.61 5.35 5.42 4.62 9.02 -1.25 6.60 -8.80 9.09 -13.71 4.69z" /></g>
+      <g className="hb hb2" fill="#3B7BF2"><path d="M453.70 193.35 c-4.54 -2.35 -6.60 -5.64 -6.60 -10.63 0 -7.48 3.52 -11.29 11.73 -12.75 10.70 -1.83 17.22 11.80 9.82 20.60 -3.81 4.47 -9.53 5.50 -14.95 2.79z" /></g>
+      <g className="hb hb3" fill="#3B7BF2"><path d="M491.08 180.60 c-6.16 -2.64 -9.53 -8.06 -9.53 -15.32 0 -10.41 7.33 -17.88 17.44 -17.96 9.68 0 16.27 6.67 16.27 16.49 0 7.18 -3.81 13.12 -10.41 16.56 -3.30 1.69 -10.11 1.83 -13.78 0.22z" /></g>
+    </svg>
+  )
+}
+
 function HexReceptionist({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
@@ -196,18 +203,13 @@ function HexReceptionist({ size = 80 }) {
 }
 
 function HexMessenger({ size = 80 }) {
+  /* FILLED dots, not hollow. Same positions as parent brand but same shape = filled */
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      <g className="hb hb1" fill="none" stroke="#6B9AEA" strokeWidth="2" opacity="0.45">
-        <path d="M424.23 202.37 c-2.05 -1.83 -2.42 -2.64 -2.42 -5.42 0 -4.18 2.05 -7.11 5.94 -8.50 2.57 -0.88 3.22 -0.88 5.57 0.22 3.37 1.61 5.35 5.42 4.62 9.02 -1.25 6.60 -8.80 9.09 -13.71 4.69z" />
-      </g>
-      <g className="hb hb2" fill="none" stroke="#6B9AEA" strokeWidth="2" opacity="0.45">
-        <path d="M453.70 193.35 c-4.54 -2.35 -6.60 -5.64 -6.60 -10.63 0 -7.48 3.52 -11.29 11.73 -12.75 10.70 -1.83 17.22 11.80 9.82 20.60 -3.81 4.47 -9.53 5.50 -14.95 2.79z" />
-      </g>
-      <g className="hb hb3" fill="none" stroke="#6B9AEA" strokeWidth="2" opacity="0.45">
-        <path d="M491.08 180.60 c-6.16 -2.64 -9.53 -8.06 -9.53 -15.32 0 -10.41 7.33 -17.88 17.44 -17.96 9.68 0 16.27 6.67 16.27 16.49 0 7.18 -3.81 13.12 -10.41 16.56 -3.30 1.69 -10.11 1.83 -13.78 0.22z" />
-      </g>
+      <g className="md md1" fill="#3B7BF2"><path d="M424.23 202.37 c-2.05 -1.83 -2.42 -2.64 -2.42 -5.42 0 -4.18 2.05 -7.11 5.94 -8.50 2.57 -0.88 3.22 -0.88 5.57 0.22 3.37 1.61 5.35 5.42 4.62 9.02 -1.25 6.60 -8.80 9.09 -13.71 4.69z" /></g>
+      <g className="md md2" fill="#3B7BF2"><path d="M453.70 193.35 c-4.54 -2.35 -6.60 -5.64 -6.60 -10.63 0 -7.48 3.52 -11.29 11.73 -12.75 10.70 -1.83 17.22 11.80 9.82 20.60 -3.81 4.47 -9.53 5.50 -14.95 2.79z" /></g>
+      <g className="md md3" fill="#3B7BF2"><path d="M491.08 180.60 c-6.16 -2.64 -9.53 -8.06 -9.53 -15.32 0 -10.41 7.33 -17.88 17.44 -17.96 9.68 0 16.27 6.67 16.27 16.49 0 7.18 -3.81 13.12 -10.41 16.56 -3.30 1.69 -10.11 1.83 -13.78 0.22z" /></g>
     </svg>
   )
 }
@@ -216,20 +218,17 @@ function HexOutreach({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      <g className="pp pp1" fill="#3B7BF2" opacity="0">
-        <path d="M474 174 L450 171 L457 183 L450 195 Z" />
-      </g>
-      <g className="pp pp2" fill="#3B7BF2" opacity="0">
-        <path d="M474 174 L450 171 L457 183 L450 195 Z" />
-      </g>
-      <g className="pp pp3" fill="#3B7BF2" opacity="0">
-        <path d="M474 174 L450 171 L457 183 L450 195 Z" />
-      </g>
+      {/* Static base plane always visible */}
+      <path d="M474 174 L450 171 L457 183 L450 195 Z" fill="#3B7BF2" opacity="0.25" />
+      <g className="pp pp1" fill="#3B7BF2"><path d="M474 174 L450 171 L457 183 L450 195 Z" /></g>
+      <g className="pp pp2" fill="#3B7BF2"><path d="M474 174 L450 171 L457 183 L450 195 Z" /></g>
+      <g className="pp pp3" fill="#3B7BF2"><path d="M474 174 L450 171 L457 183 L450 195 Z" /></g>
     </svg>
   )
 }
 
 function HexSpace({ size = 80 }) {
+  /* Carousel: one shape at a time (original behavior) */
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
@@ -245,12 +244,12 @@ function HexFlow({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      <path d="M422 195 Q440 175 460 185" fill="none" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl1" />
-      <path d="M432 185 Q450 165 470 175" fill="none" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl2" />
-      <path d="M442 195 Q460 178 480 185" fill="none" stroke="#6B9AEA" strokeWidth="1.5" strokeLinecap="round" className="fl-line fl3" />
-      <circle cx="422" cy="195" r="3.5" fill="#6B9AEA" className="fl-dot fl-dot1" />
-      <circle cx="450" cy="173" r="3" fill="#6B9AEA" className="fl-dot fl-dot2" />
-      <circle cx="480" cy="185" r="3.5" fill="#6B9AEA" className="fl-dot fl-dot3" />
+      <path d="M422 195 Q440 175 460 185" fill="none" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
+      <path d="M432 185 Q450 165 470 175" fill="none" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b2" />
+      <path d="M442 195 Q460 178 480 185" fill="none" stroke="#6B9AEA" strokeWidth="1.5" strokeLinecap="round" className="fl-line fl-b3" />
+      <circle cx="422" cy="195" r="3.5" fill="#6B9AEA" className="fl-out fl-out1" />
+      <circle cx="450" cy="173" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
+      <circle cx="480" cy="185" r="3.5" fill="#6B9AEA" className="fl-out fl-out3" />
     </svg>
   )
 }
@@ -276,7 +275,7 @@ function IconRow({ label, description, variants, hexComponent: HexComp, sizes = 
       {description && <p className="text-sm text-text-secondary mb-6">{description}</p>}
       {HexComp && (
         <div className="mb-8">
-          <p className="text-[10px] font-semibold text-text-secondary uppercase tracking-wider mb-3">Hex Logo Version</p>
+          <p className="text-[10px] font-semibold text-text-secondary uppercase tracking-wider mb-3">Hex Logo</p>
           <div className="flex items-end gap-6">
             {[100, 48].map(s => (
               <div key={s} className="flex flex-col items-center gap-2">
@@ -319,8 +318,7 @@ export default function IconExplorationPage() {
   return (
     <div className="min-h-screen bg-bg pt-28 pb-20">
       <style jsx global>{`
-        /* ═══ Waveform bars (Receptionist) ═══
-           10s heartbeat: color shifts #6B9AEA -> #2D6AE0 */
+        /* ═══ Waveform bars (Receptionist) ═══ */
         .vb1 { animation: vbPulse 10s ease-in-out infinite 0s; }
         .vb2 { animation: vbPulse 10s ease-in-out infinite 0.1s; }
         .vb3 { animation: vbPulse 10s ease-in-out infinite 0.2s; }
@@ -336,8 +334,7 @@ export default function IconExplorationPage() {
           100% { opacity: 0.55; fill: #6B9AEA; }
         }
 
-        /* ═══ Messenger dots (scale pulse) ═══
-           Heartbeat: scale 1 -> 1.3 -> 1 -> 1.2 -> 1 */
+        /* ═══ Messenger dots: filled, scale pulse ═══ */
         .md1 { animation: mdDot 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
         .md2 { animation: mdDot 10s ease-in-out infinite 0.15s; transform-box: fill-box; transform-origin: center; }
         .md3 { animation: mdDot 10s ease-in-out infinite 0.3s; transform-box: fill-box; transform-origin: center; }
@@ -350,116 +347,109 @@ export default function IconExplorationPage() {
           100% { transform: scale(1); opacity: 0.45; }
         }
 
-        /* ═══ Paper planes (Outreach) ═══
-           Fly from lower-left outward upper-right, staggered */
+        /* ═══ Paper planes (Outreach): visible at rest ═══ */
         .pp1 { animation: ppFly 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
         .pp2 { animation: ppFly 10s ease-in-out infinite 0.8s; transform-box: fill-box; transform-origin: center; }
         .pp3 { animation: ppFly 10s ease-in-out infinite 1.6s; transform-box: fill-box; transform-origin: center; }
         @keyframes ppFly {
-          0%   { opacity: 0; transform: translate(-8px, 6px) scale(0.6); }
-          2%   { opacity: 1; transform: translate(0, 0) scale(1); }
-          5%   { opacity: 1; transform: translate(5px, -4px) scale(1.05); }
-          8%   { opacity: 0; transform: translate(12px, -8px) scale(0.7); }
-          10%  { opacity: 0; transform: translate(-8px, 6px) scale(0.6); }
-          100% { opacity: 0; transform: translate(-8px, 6px) scale(0.6); }
+          0%   { opacity: 0.3; transform: translate(0, 0) scale(1); }
+          2%   { opacity: 1;   transform: translate(0, 0) scale(1.05); }
+          5%   { opacity: 1;   transform: translate(5px, -4px) scale(1.05); }
+          8%   { opacity: 0;   transform: translate(12px, -8px) scale(0.7); }
+          12%  { opacity: 0.3; transform: translate(0, 0) scale(1); }
+          100% { opacity: 0.3; transform: translate(0, 0) scale(1); }
         }
 
-        /* ═══ Shape carousel (Space) ═══
-           16s cycle, 4 shapes, one visible at a time */
+        /* ═══ Space shapes: all visible, pulse in sequence ═══ */
+        .sp1 { animation: spPulse 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
+        .sp2 { animation: spPulse 10s ease-in-out infinite 2.5s; transform-box: fill-box; transform-origin: center; }
+        .sp3 { animation: spPulse 10s ease-in-out infinite 5s; transform-box: fill-box; transform-origin: center; }
+        .sp4 { animation: spPulse 10s ease-in-out infinite 7.5s; transform-box: fill-box; transform-origin: center; }
+        @keyframes spPulse {
+          0%   { opacity: 0.35; transform: scale(1); }
+          3%   { opacity: 1;    transform: scale(1.15); }
+          5%   { opacity: 0.8;  transform: scale(1.05); }
+          8%   { opacity: 0.35; transform: scale(1); }
+          100% { opacity: 0.35; transform: scale(1); }
+        }
+
+        /* ═══ Space hex: carousel (one at a time) ═══ */
         .cs-circle   { animation: csSlot1 16s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
         .cs-diamond  { animation: csSlot2 16s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
         .cs-triangle { animation: csSlot3 16s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
         .cs-square   { animation: csSlot4 16s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
         @keyframes csSlot1 {
-          0%   { opacity: 0; transform: translate(-10px, 6px) scale(0.8); }
-          3%   { opacity: 1; transform: translate(0, 0) scale(1); }
-          20%  { opacity: 1; transform: translate(0, 0) scale(1); }
-          25%  { opacity: 0; transform: translate(10px, -6px) scale(0.8); }
+          0%   { opacity: 0; transform: translate(-15px, 10px); }
+          3%   { opacity: 1; transform: translate(0, 0); }
+          20%  { opacity: 1; transform: translate(0, 0); }
+          25%  { opacity: 0; transform: translate(15px, -10px); }
           100% { opacity: 0; }
         }
         @keyframes csSlot2 {
-          0%   { opacity: 0; }
-          25%  { opacity: 0; transform: translate(-10px, 6px) scale(0.8); }
-          28%  { opacity: 1; transform: translate(0, 0) scale(1); }
-          45%  { opacity: 1; transform: translate(0, 0) scale(1); }
-          50%  { opacity: 0; transform: translate(10px, -6px) scale(0.8); }
+          0%   { opacity: 0; } 25%  { opacity: 0; transform: translate(-15px, 10px); }
+          28%  { opacity: 1; transform: translate(0, 0); }
+          45%  { opacity: 1; transform: translate(0, 0); }
+          50%  { opacity: 0; transform: translate(15px, -10px); }
           100% { opacity: 0; }
         }
         @keyframes csSlot3 {
-          0%   { opacity: 0; }
-          50%  { opacity: 0; transform: translate(-10px, 6px) scale(0.8); }
-          53%  { opacity: 1; transform: translate(0, 0) scale(1); }
-          70%  { opacity: 1; transform: translate(0, 0) scale(1); }
-          75%  { opacity: 0; transform: translate(10px, -6px) scale(0.8); }
+          0%   { opacity: 0; } 50%  { opacity: 0; transform: translate(-15px, 10px); }
+          53%  { opacity: 1; transform: translate(0, 0); }
+          70%  { opacity: 1; transform: translate(0, 0); }
+          75%  { opacity: 0; transform: translate(15px, -10px); }
           100% { opacity: 0; }
         }
         @keyframes csSlot4 {
-          0%   { opacity: 0; }
-          75%  { opacity: 0; transform: translate(-10px, 6px) scale(0.8); }
-          78%  { opacity: 1; transform: translate(0, 0) scale(1); }
-          95%  { opacity: 1; transform: translate(0, 0) scale(1); }
-          100% { opacity: 0; transform: translate(10px, -6px) scale(0.8); }
+          0%   { opacity: 0; } 75%  { opacity: 0; transform: translate(-15px, 10px); }
+          78%  { opacity: 1; transform: translate(0, 0); }
+          95%  { opacity: 1; transform: translate(0, 0); }
+          100% { opacity: 0; transform: translate(15px, -10px); }
         }
 
-        /* ═══ Flow lines + dots (data flowing) ═══
-           Lines pulse color, dots pulse + data packet travels */
-        .fl-line { animation: flLinePulse 10s ease-in-out infinite; }
-        .fl1 { animation-delay: 0s; }
-        .fl2 { animation-delay: 0.15s; }
-        .fl3 { animation-delay: 0.3s; }
-        @keyframes flLinePulse {
-          0%   { opacity: 0.25; stroke: #6B9AEA; }
-          3%   { opacity: 1;    stroke: #2D6AE0; }
-          5%   { opacity: 0.35; stroke: #6B9AEA; }
-          7%   { opacity: 0.9;  stroke: #2D6AE0; }
-          10%  { opacity: 0.25; stroke: #6B9AEA; }
-          100% { opacity: 0.25; stroke: #6B9AEA; }
+        /* ═══ Flow: lines pulse, dots light up sequentially ═══ */
+        .fl-line { animation: flLine 10s ease-in-out infinite; }
+        .fl-b1 { animation-delay: 0s; }
+        .fl-b2 { animation-delay: 0.15s; }
+        .fl-b3 { animation-delay: 0.3s; }
+        @keyframes flLine {
+          0%   { opacity: 0.3; stroke: #6B9AEA; }
+          3%   { opacity: 1;   stroke: #2D6AE0; }
+          5%   { opacity: 0.4; stroke: #6B9AEA; }
+          7%   { opacity: 0.9; stroke: #2D6AE0; }
+          10%  { opacity: 0.3; stroke: #6B9AEA; }
+          100% { opacity: 0.3; stroke: #6B9AEA; }
         }
-        .fl-dot { animation: flDotPulse 10s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
-        .fl-dot1 { animation-delay: 0s; }
-        .fl-dot2 { animation-delay: 0.15s; }
-        .fl-dot3 { animation-delay: 0.3s; }
-        @keyframes flDotPulse {
-          0%   { opacity: 0.4; fill: #6B9AEA; }
-          3%   { opacity: 1;   fill: #2D6AE0; }
-          5%   { opacity: 0.5; fill: #6B9AEA; }
-          7%   { opacity: 1;   fill: #2D6AE0; }
-          10%  { opacity: 0.4; fill: #6B9AEA; }
-          100% { opacity: 0.4; fill: #6B9AEA; }
+        .fl-src { animation: flSrc 10s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+        @keyframes flSrc {
+          0%   { opacity: 0.6; transform: scale(1); }
+          2%   { opacity: 1;   transform: scale(1.2); }
+          4%   { opacity: 0.6; transform: scale(1); }
+          100% { opacity: 0.6; transform: scale(1); }
         }
-        /* Source dot: constant pulse */
-        .fl-src { animation: flSrcPulse 10s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
-        @keyframes flSrcPulse {
-          0%   { transform: scale(1); opacity: 0.6; }
-          3%   { transform: scale(1.2); opacity: 1; }
-          7%   { transform: scale(1); opacity: 0.6; }
-          100% { transform: scale(1); opacity: 0.6; }
-        }
-        .fl-junc { animation: flDotPulse 10s ease-in-out infinite 0.1s; transform-box: fill-box; transform-origin: center; }
-        .fl-out { animation: flOutPulse 10s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+        /* Output dots: start dim, light up as data arrives */
+        .fl-out { animation: flOut 10s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
         .fl-out1 { animation-delay: 0.3s; }
-        .fl-out2 { animation-delay: 0.45s; }
-        .fl-out3 { animation-delay: 0.6s; }
-        @keyframes flOutPulse {
-          0%   { transform: scale(0.7); opacity: 0.2; fill: #6B9AEA; }
-          4%   { transform: scale(1.2); opacity: 1; fill: #2D6AE0; }
-          7%   { transform: scale(1); opacity: 0.8; fill: #3B7BF2; }
-          10%  { transform: scale(0.7); opacity: 0.2; fill: #6B9AEA; }
-          100% { transform: scale(0.7); opacity: 0.2; fill: #6B9AEA; }
+        .fl-out2 { animation-delay: 0.5s; }
+        .fl-out3 { animation-delay: 0.7s; }
+        @keyframes flOut {
+          0%   { opacity: 0.25; fill: #6B9AEA; transform: scale(0.8); }
+          4%   { opacity: 1;    fill: #2D6AE0; transform: scale(1.25); }
+          7%   { opacity: 0.7;  fill: #3B7BF2; transform: scale(1); }
+          10%  { opacity: 0.25; fill: #6B9AEA; transform: scale(0.8); }
+          100% { opacity: 0.25; fill: #6B9AEA; transform: scale(0.8); }
         }
-        /* Data packet travels from source through junction to outputs */
-        .fl-packet { animation: flPacket 10s ease-in-out infinite; }
-        @keyframes flPacket {
-          0%   { cx: 8;  cy: 28; opacity: 0; r: 2; }
-          1%   { cx: 8;  cy: 28; opacity: 1; r: 2.5; }
-          3%   { cx: 18; cy: 20; opacity: 1; r: 2; }
-          4%   { cx: 18; cy: 20; opacity: 0.8; r: 1.5; }
-          6%   { cx: 32; cy: 20; opacity: 0.6; r: 1; }
-          8%   { opacity: 0; }
+        /* Data packet travels along the middle branch */
+        .fl-packet { animation: flPkt 10s ease-in-out infinite; }
+        @keyframes flPkt {
+          0%   { cx: 6;  cy: 20; opacity: 0; }
+          1%   { cx: 6;  cy: 20; opacity: 1; }
+          3%   { cx: 18; cy: 20; opacity: 1; }
+          5%   { cx: 30; cy: 20; opacity: 0.8; }
+          7%   { cx: 32; cy: 20; opacity: 0; }
           100% { opacity: 0; }
         }
 
-        /* ═══ Heartbeat dots (Parent brand / Messenger hex / Avatar V3) ═══ */
+        /* ═══ Heartbeat dots (Parent brand, Avatar V3) ═══ */
         .hb1 { animation: hbDot 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
         .hb2 { animation: hbDot 10s ease-in-out infinite 0.15s; transform-box: fill-box; transform-origin: center; }
         .hb3 { animation: hbDot 10s ease-in-out infinite 0.3s; transform-box: fill-box; transform-origin: center; }
@@ -473,69 +463,72 @@ export default function IconExplorationPage() {
         }
 
         /* ═══ Avatar rings ═══ */
-        .av-ring1 { animation: avRingPulse 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
-        .av-ring2 { animation: avRingPulse 10s ease-in-out infinite 0.2s; transform-box: fill-box; transform-origin: center; }
-        @keyframes avRingPulse {
-          0%   { transform: scale(0.95); opacity: 0.15; }
-          3%   { transform: scale(1.05); opacity: 0.5; }
-          5%   { transform: scale(0.98); opacity: 0.25; }
-          7%   { transform: scale(1.03); opacity: 0.4; }
-          10%  { transform: scale(0.95); opacity: 0.15; }
-          100% { transform: scale(0.95); opacity: 0.15; }
+        .av-ring1 { animation: avRing 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
+        .av-ring2 { animation: avRing 10s ease-in-out infinite 0.2s; transform-box: fill-box; transform-origin: center; }
+        @keyframes avRing {
+          0%   { opacity: 0.15; transform: scale(0.95); }
+          3%   { opacity: 0.5;  transform: scale(1.05); }
+          5%   { opacity: 0.25; transform: scale(0.98); }
+          7%   { opacity: 0.4;  transform: scale(1.03); }
+          10%  { opacity: 0.15; transform: scale(0.95); }
+          100% { opacity: 0.15; transform: scale(0.95); }
         }
         .av-live { animation: avLive 2s ease-in-out infinite; }
-        @keyframes avLive {
-          0%, 100% { opacity: 0.5; }
-          50% { opacity: 1; }
-        }
+        @keyframes avLive { 0%, 100% { opacity: 0.5; } 50% { opacity: 1; } }
       `}</style>
 
       <div className="max-w-6xl mx-auto px-6">
         <AnimatedSection>
-          <Badge variant="blue" className="mb-4">Design Exploration v3</Badge>
+          <Badge variant="blue" className="mb-4">Design Exploration v4</Badge>
           <h1 className="text-4xl font-extrabold text-text tracking-tight mb-3" style={{ fontFamily: 'var(--font-outfit)' }}>
             Product Icon Family
           </h1>
-          <p className="text-text-secondary max-w-2xl mb-2">
-            All icons use brand blue (#3B7BF2 / #6B9AEA / #2D6AE0). All animations use 10s heartbeat cycle (brief burst, long rest) matching the original hex accent patterns. Each product shows hex logo + accent-only variants.
+          <p className="text-text-secondary max-w-2xl">
+            All icons always visible at rest. Animations burst briefly then rest.
+            Brand blue only. Hex versions alongside accent-only versions.
           </p>
         </AnimatedSection>
 
         <div className="gradient-divider my-10" />
 
-        <IconRow label="Receptionist" description="Voice waveform. Undecided. All use the same vbPulse animation from the original hex." hexComponent={HexReceptionist}
+        <IconRow label="JotilLabs (Parent)" description="Ascending heartbeat dots. The parent brand identity." hexComponent={HexJotilLabs}
+          variants={[{ name: 'Parent brand logo', Component: JotilLabsLogo, picked: true }]}
+        />
+        <div className="gradient-divider my-10" />
+
+        <IconRow label="Receptionist" description="Voice waveform. vbPulse animation (color shift #6B9AEA to #2D6AE0)." hexComponent={HexReceptionist}
           variants={[
-            { name: 'Symmetric 5-bar' , Component: ReceptionistV1 },
+            { name: 'Symmetric 5-bar', Component: ReceptionistV1 },
             { name: 'Thin 5-bar', Component: ReceptionistV2 },
             { name: 'Asymmetric 6-bar', Component: ReceptionistV3 },
           ]}
         />
         <div className="gradient-divider my-10" />
 
-        <IconRow label="Messenger" description="Typing dots. V2 picked. Uses heartbeat scale pulse." hexComponent={HexMessenger}
-          variants={[{ name: 'Three dots (heartbeat pulse)', Component: MessengerV2, picked: true }]}
+        <IconRow label="Messenger" description="FILLED dots (not hollow). Heartbeat scale pulse." hexComponent={HexMessenger}
+          variants={[{ name: 'Three filled dots', Component: MessengerV2, picked: true }]}
         />
         <div className="gradient-divider my-10" />
 
-        <IconRow label="Outreach" description="Paper planes fly outward. Uses the original ppFly trajectory (translate + scale + fade, staggered 0.8s)." hexComponent={HexOutreach}
-          variants={[{ name: 'Paper planes (flight trajectory)', Component: OutreachV1, picked: true }]}
+        <IconRow label="Outreach" description="Paper plane always visible at 30% opacity. Bursts with flight trajectory, returns to rest." hexComponent={HexOutreach}
+          variants={[{ name: 'Paper plane (always visible, flight on burst)', Component: OutreachV1, picked: true }]}
         />
         <div className="gradient-divider my-10" />
 
-        <IconRow label="Space" description="Shape carousel. One shape visible at a time, 16s cycle. Slide in, hold, slide out." hexComponent={HexSpace}
-          variants={[{ name: 'Shape carousel (circle > diamond > triangle > square)', Component: SpaceV1, picked: true }]}
+        <IconRow label="Space" description="Accent-only: 4 shapes always visible, each pulses in sequence. Hex: carousel (one shape at a time, original behavior)." hexComponent={HexSpace}
+          variants={[{ name: '4 shapes grid, sequential pulse', Component: SpaceV1, picked: true }]}
         />
         <div className="gradient-divider my-10" />
 
-        <IconRow label="Flow" description="Branching flow. Diagonal alignment. Source dot sends data through junction to 3 output dots. Outputs 'light up' sequentially as data arrives." hexComponent={HexFlow}
-          variants={[{ name: 'Diagonal branch, data packet flows from source to outputs', Component: FlowV3, picked: true }]}
+        <IconRow label="Flow" description="Horizontal branch layout, rotated 45deg. Data packet travels from source through junction to outputs. Outputs light up sequentially." hexComponent={HexFlow}
+          variants={[{ name: 'Diagonal branch, data packet travels to outputs', Component: FlowV3, picked: true }]}
         />
         <div className="gradient-divider my-10" />
 
         <IconRow label="Avatar" description="Human-like AI presence. 4 options. None picked yet." hexComponent={HexAvatar}
           variants={[
-            { name: 'Pulsing rings + face (video call incoming)', Component: AvatarV1 },
-            { name: 'Face + speaking waveform (AI that talks)', Component: AvatarV2 },
+            { name: 'Pulsing rings + face', Component: AvatarV1 },
+            { name: 'Face + speaking waveform', Component: AvatarV2 },
             { name: 'Ascending circles with face (brand-style)', Component: AvatarV3 },
             { name: 'Video frame + face + live dot', Component: AvatarV4 },
           ]}

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -97,20 +97,20 @@ function SpaceV1({ size = 40 }) {
   )
 }
 
-/* ── FLOW: Three parallel curved lines with dots (matches hex accent exactly) ──
-   Same curves as ProductLogos.jsx FlowLogo, scaled to 40x40, rotated 45deg.
-   Data travels along the curves from start dots to end dots. */
+/* ── FLOW: Three parallel curves flowing lower-left to upper-right ──
+   No CSS rotation. Curves positioned naturally diagonal in the viewBox.
+   Matches the hex accent direction. Each line has a dot at the end. */
 function FlowV3({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" style={{ transform: 'rotate(-45deg)' }}>
-      {/* Three parallel Q-curves flowing upper-right (same shape as hex accent) */}
-      <path d="M4 28 Q14 14 26 20" fill="none" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
-      <path d="M10 24 Q20 10 32 16" fill="none" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b2" />
-      <path d="M16 28 Q26 16 38 20" fill="none" stroke="#6B9AEA" strokeWidth="1.5" strokeLinecap="round" className="fl-line fl-b3" />
-      {/* Endpoint dots */}
-      <circle cx="26" cy="20" r="3.5" fill="#6B9AEA" className="fl-out fl-out1" />
-      <circle cx="32" cy="16" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
-      <circle cx="38" cy="20" r="3.5" fill="#6B9AEA" className="fl-out fl-out3" />
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      {/* Three parallel Q-curves, lower-left to upper-right */}
+      <path d="M2 32 Q16 18 30 24" fill="none" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
+      <path d="M8 28 Q22 10 36 16" fill="none" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b2" />
+      <path d="M14 36 Q28 22 38 26" fill="none" stroke="#6B9AEA" strokeWidth="1.5" strokeLinecap="round" className="fl-line fl-b3" />
+      {/* Endpoint dots at the end of each curve */}
+      <circle cx="30" cy="24" r="3.5" fill="#6B9AEA" className="fl-out fl-out1" />
+      <circle cx="36" cy="16" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
+      <circle cx="38" cy="26" r="3.5" fill="#6B9AEA" className="fl-out fl-out3" />
     </svg>
   )
 }

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -2,339 +2,286 @@
 
 import { AnimatedSection } from '@/components/ui/AnimatedSection'
 import { Badge } from '@/components/ui/Badge'
+import { HexContainer } from '@/components/ui/Logo'
 
 /* ─────────────────────────────────────────────────
-   ACCENT-FORWARD ANIMATED ICONS
-   Each icon has its own CSS keyframe animation
-   matching the original hex accent behavior.
+   UNIFIED COLOR: All icons use brand blue family
+   Primary: #3B7BF2  Light: #6B9AEA  Dark: #2D6AE0
 ───────────────────────────────────────────────────── */
+const C = { primary: '#3B7BF2', light: '#6B9AEA', dark: '#2D6AE0' }
 
-// ── RECEPTIONIST: Waveform bars ──
-function ReceptionistV1({ size = 40, color = '#3B7BF2' }) {
-  const barAnim = (delay) => ({
-    animation: `waveBar 1.2s ease-in-out ${delay}s infinite alternate`,
-    transformBox: 'fill-box',
-    transformOrigin: 'center bottom',
-  })
+/* ═══ RECEPTIONIST: Waveform bars ═══ */
+function ReceptionistV1({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <rect x="4" y="16" width="5" height="8" rx="2.5" fill={color} opacity="0.5" style={barAnim(0)} />
-      <rect x="11" y="10" width="5" height="20" rx="2.5" fill={color} opacity="0.65" style={barAnim(0.1)} />
-      <rect x="18" y="6" width="5" height="28" rx="2.5" fill={color} style={barAnim(0.2)} />
-      <rect x="25" y="12" width="5" height="16" rx="2.5" fill={color} opacity="0.65" style={barAnim(0.3)} />
-      <rect x="32" y="14" width="5" height="12" rx="2.5" fill={color} opacity="0.5" style={barAnim(0.4)} />
+      <rect x="4" y="16" width="5" height="8" rx="2.5" fill={C.light} className="rc-bar1" />
+      <rect x="11" y="10" width="5" height="20" rx="2.5" fill={C.primary} className="rc-bar2" />
+      <rect x="18" y="6" width="5" height="28" rx="2.5" fill={C.dark} className="rc-bar3" />
+      <rect x="25" y="12" width="5" height="16" rx="2.5" fill={C.primary} className="rc-bar4" />
+      <rect x="32" y="14" width="5" height="12" rx="2.5" fill={C.light} className="rc-bar5" />
     </svg>
   )
 }
 
-function ReceptionistV2({ size = 40, color = '#3B7BF2' }) {
-  const barAnim = (delay) => ({
-    animation: `waveBar 1.4s ease-in-out ${delay}s infinite alternate`,
-    transformBox: 'fill-box',
-    transformOrigin: 'center bottom',
-  })
+function ReceptionistV2({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <rect x="6" y="18" width="4" height="4" rx="2" fill={color} opacity="0.4" style={barAnim(0)} />
-      <rect x="13" y="12" width="4" height="16" rx="2" fill={color} opacity="0.6" style={barAnim(0.12)} />
-      <rect x="20" y="6" width="4" height="28" rx="2" fill={color} style={barAnim(0.24)} />
-      <rect x="27" y="10" width="4" height="20" rx="2" fill={color} opacity="0.6" style={barAnim(0.36)} />
-      <rect x="34" y="16" width="4" height="8" rx="2" fill={color} opacity="0.4" style={barAnim(0.48)} />
+      <rect x="6" y="18" width="4" height="4" rx="2" fill={C.light} className="rc-bar1" />
+      <rect x="13" y="12" width="4" height="16" rx="2" fill={C.light} className="rc-bar2" />
+      <rect x="20" y="6" width="4" height="28" rx="2" fill={C.primary} className="rc-bar3" />
+      <rect x="27" y="10" width="4" height="20" rx="2" fill={C.light} className="rc-bar4" />
+      <rect x="34" y="16" width="4" height="8" rx="2" fill={C.light} className="rc-bar5" />
     </svg>
   )
 }
 
-function ReceptionistV3({ size = 40, color = '#3B7BF2' }) {
-  const barAnim = (delay) => ({
-    animation: `waveBar 1.0s ease-in-out ${delay}s infinite alternate`,
-    transformBox: 'fill-box',
-    transformOrigin: 'center bottom',
-  })
+function ReceptionistV3({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <rect x="5" y="17" width="3.5" height="6" rx="1.75" fill={color} opacity="0.45" style={barAnim(0)} />
-      <rect x="11" y="12" width="3.5" height="16" rx="1.75" fill={color} opacity="0.6" style={barAnim(0.08)} />
-      <rect x="17" y="7" width="4" height="26" rx="2" fill={color} style={barAnim(0.16)} />
-      <rect x="23.5" y="9" width="3.5" height="22" rx="1.75" fill={color} opacity="0.75" style={barAnim(0.24)} />
-      <rect x="29.5" y="13" width="3.5" height="14" rx="1.75" fill={color} opacity="0.55" style={barAnim(0.32)} />
-      <rect x="35.5" y="17" width="3.5" height="6" rx="1.75" fill={color} opacity="0.35" style={barAnim(0.4)} />
+      <rect x="5" y="17" width="3.5" height="6" rx="1.75" fill={C.light} className="rc-bar1" />
+      <rect x="11" y="12" width="3.5" height="16" rx="1.75" fill={C.light} className="rc-bar2" />
+      <rect x="17" y="7" width="4" height="26" rx="2" fill={C.primary} className="rc-bar3" />
+      <rect x="23.5" y="9" width="3.5" height="22" rx="1.75" fill={C.primary} className="rc-bar4" />
+      <rect x="29.5" y="13" width="3.5" height="14" rx="1.75" fill={C.light} className="rc-bar5" />
+      <rect x="35.5" y="17" width="3.5" height="6" rx="1.75" fill={C.light} className="rc-bar6" />
     </svg>
   )
 }
 
-// ── MESSENGER: Typing dots ── (V2 is the pick)
-function MessengerV1({ size = 40, color = '#6366F1' }) {
-  const dotAnim = (delay) => ({
-    animation: `typingDot 1.4s ease-in-out ${delay}s infinite`,
-    transformBox: 'fill-box',
-    transformOrigin: 'center',
-  })
+/* ═══ MESSENGER: Typing dots (V2 picked) ═══ */
+function MessengerV2({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="10" cy="24" r="4" stroke={color} strokeWidth="2" fill="none" opacity="0.5" style={dotAnim(0)} />
-      <circle cx="20" cy="18" r="5.5" stroke={color} strokeWidth="2" fill="none" opacity="0.7" style={dotAnim(0.15)} />
-      <circle cx="31" cy="14" r="7" stroke={color} strokeWidth="2" fill="none" style={dotAnim(0.3)} />
+      <circle cx="10" cy="20" r="3" fill={C.primary} className="msg-dot1" />
+      <circle cx="20" cy="20" r="3" fill={C.primary} className="msg-dot2" />
+      <circle cx="30" cy="20" r="3" fill={C.primary} className="msg-dot3" />
     </svg>
   )
 }
 
-function MessengerV2({ size = 40, color = '#6366F1' }) {
-  const dotAnim = (delay) => ({
-    animation: `typingDot 1.4s ease-in-out ${delay}s infinite`,
-    transformBox: 'fill-box',
-    transformOrigin: 'center',
-  })
+/* ═══ OUTREACH: Paper plane (V1 picked) ═══ */
+function OutreachV1({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="10" cy="20" r="3" fill={color} opacity="0.35" style={dotAnim(0)} />
-      <circle cx="20" cy="20" r="3" fill={color} opacity="0.6" style={dotAnim(0.2)} />
-      <circle cx="30" cy="20" r="3" fill={color} style={dotAnim(0.4)} />
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" className="outreach-plane">
+      <path d="M6 20l28-14-8 16-6-4-14 2z" fill={C.primary} opacity="0.12" />
+      <path d="M6 20l28-14-8 16-6-4-14 2z" stroke={C.primary} strokeWidth="1.8" strokeLinejoin="round" fill="none" />
+      <path d="M20 18l6 14" stroke={C.primary} strokeWidth="1.5" strokeLinecap="round" />
     </svg>
   )
 }
 
-function MessengerV3({ size = 40, color = '#6366F1' }) {
-  const dotAnim = (delay) => ({
-    animation: `typingDot 1.4s ease-in-out ${delay}s infinite`,
-    transformBox: 'fill-box',
-    transformOrigin: 'center',
-  })
+/* ═══ SPACE: Mixed shapes (V1 picked) ═══ */
+function SpaceV1({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <path d="M6 10h28a2 2 0 012 2v14a2 2 0 01-2 2H14l-6 5v-5H6a2 2 0 01-2-2V12a2 2 0 012-2z" stroke={color} strokeWidth="1.8" fill="none" opacity="0.25" />
-      <circle cx="13" cy="19" r="2.5" fill={color} opacity="0.4" style={dotAnim(0)} />
-      <circle cx="20" cy="19" r="2.5" fill={color} opacity="0.65" style={dotAnim(0.2)} />
-      <circle cx="27" cy="19" r="2.5" fill={color} style={dotAnim(0.4)} />
+      <circle cx="12" cy="12" r="6" fill={C.primary} className="sp-shape1" />
+      <rect x="22" y="6" width="12" height="12" rx="2" fill={C.primary} className="sp-shape2" />
+      <polygon points="12,28 18,40 6,40" fill={C.primary} className="sp-shape3" />
+      <polygon points="28,26 34,32 28,38 22,32" fill={C.primary} className="sp-shape4" />
     </svg>
   )
 }
 
-// ── OUTREACH: Paper planes ── (V1 is the pick)
-function OutreachV1({ size = 40, color = '#0EA5E9' }) {
+/* ═══ FLOW: Branching (V3 picked) ═══ */
+function FlowV3({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <g style={{ animation: 'planeFly 3s ease-in-out infinite' }}>
-        <path d="M6 20l28-14-8 16-6-4-14 2z" fill={color} opacity="0.12" />
-        <path d="M6 20l28-14-8 16-6-4-14 2z" stroke={color} strokeWidth="1.8" strokeLinejoin="round" fill="none" />
-        <path d="M20 18l6 14" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+      <circle cx="6" cy="20" r="4" fill={C.primary} className="fl-dot-in" />
+      <path d="M10 20H18" stroke={C.primary} strokeWidth="2" strokeLinecap="round" className="fl-line" />
+      <path d="M18 20Q22 20 26 12" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch1" />
+      <path d="M18 20Q22 20 26 20" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch2" />
+      <path d="M18 20Q22 20 26 28" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch3" />
+      <circle cx="30" cy="12" r="3" fill={C.light} className="fl-dot1" />
+      <circle cx="30" cy="20" r="3" fill={C.primary} className="fl-dot2" />
+      <circle cx="30" cy="28" r="3" fill={C.light} className="fl-dot3" />
+    </svg>
+  )
+}
+
+/* ═══ AVATAR: New variations ═══ */
+function AvatarV1({ size = 40 }) {
+  // Pulsing rings + face
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <circle cx="20" cy="20" r="16" stroke={C.light} strokeWidth="1.2" fill="none" className="av-ring1" />
+      <circle cx="20" cy="20" r="11" stroke={C.primary} strokeWidth="1.2" fill="none" className="av-ring2" />
+      <circle cx="20" cy="18" r="6" fill={C.primary} opacity="0.08" />
+      <circle cx="18" cy="16.5" r="1.2" fill={C.primary} />
+      <circle cx="22" cy="16.5" r="1.2" fill={C.primary} />
+      <path d="M17 20.5Q20 23 23 20.5" stroke={C.primary} strokeWidth="1.2" strokeLinecap="round" fill="none" />
+      <path d="M12 32Q20 27 28 32" stroke={C.light} strokeWidth="2" strokeLinecap="round" fill="none" />
+    </svg>
+  )
+}
+
+function AvatarV2({ size = 40 }) {
+  // Face + speaking waveform
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <circle cx="20" cy="16" r="8" fill={C.primary} opacity="0.06" stroke={C.primary} strokeWidth="1.5" />
+      <circle cx="17.5" cy="14.5" r="1.3" fill={C.primary} />
+      <circle cx="22.5" cy="14.5" r="1.3" fill={C.primary} />
+      <path d="M17 19Q20 22 23 19" stroke={C.primary} strokeWidth="1.3" strokeLinecap="round" fill="none" />
+      <rect x="11" y="30" width="2.5" height="5" rx="1.25" fill={C.light} className="rc-bar1" />
+      <rect x="15.5" y="28" width="2.5" height="9" rx="1.25" fill={C.primary} className="rc-bar2" />
+      <rect x="20" y="27" width="2.5" height="11" rx="1.25" fill={C.dark} className="rc-bar3" />
+      <rect x="24.5" y="29" width="2.5" height="7" rx="1.25" fill={C.primary} className="rc-bar4" />
+      <rect x="29" y="31" width="2.5" height="3" rx="1.25" fill={C.light} className="rc-bar5" />
+    </svg>
+  )
+}
+
+function AvatarV3({ size = 40 }) {
+  // Glowing orb with face
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <circle cx="20" cy="20" r="16" fill={C.primary} opacity="0.04" className="av-ring1" />
+      <circle cx="20" cy="20" r="12" fill={C.primary} opacity="0.06" />
+      <circle cx="20" cy="18" r="7" fill={C.primary} opacity="0.04" stroke={C.primary} strokeWidth="1.2" />
+      <circle cx="17.5" cy="16" r="1.5" fill={C.primary} opacity="0.8" />
+      <circle cx="22.5" cy="16" r="1.5" fill={C.primary} opacity="0.8" />
+      <path d="M17 21Q20 24 23 21" stroke={C.primary} strokeWidth="1.4" strokeLinecap="round" fill="none" />
+    </svg>
+  )
+}
+
+function AvatarV4({ size = 40 }) {
+  // Two merging circles (human meets AI)
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <circle cx="15" cy="20" r="10" stroke={C.light} strokeWidth="1.5" fill={C.primary} opacity="0.04" className="av-merge1" />
+      <circle cx="25" cy="20" r="10" stroke={C.light} strokeWidth="1.5" fill={C.primary} opacity="0.04" className="av-merge2" />
+      <circle cx="18.5" cy="18" r="1.2" fill={C.primary} />
+      <circle cx="21.5" cy="18" r="1.2" fill={C.primary} />
+      <path d="M18 22Q20 24.5 22 22" stroke={C.primary} strokeWidth="1.2" strokeLinecap="round" fill="none" />
+    </svg>
+  )
+}
+
+/* ═══ HEX VERSIONS: Show accent inside subtle hex outline ═══ */
+function HexReceptionist({ size = 80 }) {
+  const s = size / 80
+  return (
+    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+      <HexContainer />
+      <rect x="424.5" y="188" width="5" height="14" rx="2.5" fill={C.light} className="rc-bar1" />
+      <rect x="435.5" y="178" width="5" height="24" rx="2.5" fill={C.primary} className="rc-bar2" />
+      <rect x="446.5" y="170" width="5" height="30" rx="2.5" fill={C.dark} className="rc-bar3" />
+      <rect x="457.5" y="170" width="5" height="20" rx="2.5" fill={C.primary} className="rc-bar4" />
+      <rect x="468.5" y="167" width="5" height="16" rx="2.5" fill={C.light} className="rc-bar5" />
+    </svg>
+  )
+}
+
+function HexMessenger({ size = 80 }) {
+  return (
+    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+      <HexContainer />
+      <circle cx="430" cy="197" r="5" fill={C.primary} className="msg-dot1" />
+      <circle cx="455" cy="187" r="7" fill={C.primary} className="msg-dot2" />
+      <circle cx="485" cy="177" r="9" fill={C.primary} className="msg-dot3" />
+    </svg>
+  )
+}
+
+function HexOutreach({ size = 80 }) {
+  return (
+    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+      <HexContainer />
+      <g className="outreach-plane">
+        <path d="M430 190l35-16-10 18-7-4-18 2z" fill={C.primary} opacity="0.12" />
+        <path d="M430 190l35-16-10 18-7-4-18 2z" stroke={C.primary} strokeWidth="2" strokeLinejoin="round" fill="none" />
+        <path d="M448 188l6 14" stroke={C.primary} strokeWidth="1.8" strokeLinecap="round" />
       </g>
     </svg>
   )
 }
 
-function OutreachV2({ size = 40, color = '#0EA5E9' }) {
-  const planeAnim = (delay) => ({
-    animation: `planeDispatch 2.5s ease-in-out ${delay}s infinite`,
-    transformBox: 'fill-box',
-    transformOrigin: 'center',
-  })
+function HexSpace({ size = 80 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <g opacity="0.35" transform="translate(4, 24) scale(0.6)" style={planeAnim(0)}>
-        <path d="M0 8l20-8-6 10-4-3L0 8z" fill={color} />
-      </g>
-      <g opacity="0.65" transform="translate(12, 14) scale(0.8)" style={planeAnim(0.6)}>
-        <path d="M0 8l20-8-6 10-4-3L0 8z" fill={color} />
-      </g>
-      <g transform="translate(18, 4) scale(1)" style={planeAnim(1.2)}>
-        <path d="M0 8l20-8-6 10-4-3L0 8z" fill={color} />
-      </g>
+    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+      <HexContainer />
+      <circle cx="440" cy="175" r="7" fill={C.primary} className="sp-shape1" />
+      <rect x="455" y="168" width="14" height="14" rx="2" fill={C.primary} className="sp-shape2" />
+      <polygon points="440,190 447,203 433,203" fill={C.primary} className="sp-shape3" />
+      <polygon points="462,190 469,197 462,204 455,197" fill={C.primary} className="sp-shape4" />
     </svg>
   )
 }
 
-function OutreachV3({ size = 40, color = '#0EA5E9' }) {
+function HexFlow({ size = 80 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <g style={{ animation: 'planeFly 3s ease-in-out infinite' }}>
-        <path d="M6 34L8 20 34 6 20 32 16 22z" fill={color} opacity="0.12" />
-        <path d="M6 34L34 6" stroke={color} strokeWidth="2" strokeLinecap="round" />
-        <path d="M34 6L20 32" stroke={color} strokeWidth="1.8" strokeLinecap="round" />
-        <path d="M20 32L16 22L6 34" stroke={color} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
-      </g>
+    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+      <HexContainer />
+      <circle cx="425" cy="185" r="5" fill={C.primary} className="fl-dot-in" />
+      <path d="M430 185H445" stroke={C.primary} strokeWidth="2.5" strokeLinecap="round" className="fl-line" />
+      <path d="M445 185Q452 185 460 172" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch1" />
+      <path d="M445 185Q452 185 460 185" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch2" />
+      <path d="M445 185Q452 185 460 198" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch3" />
+      <circle cx="464" cy="172" r="4" fill={C.light} className="fl-dot1" />
+      <circle cx="464" cy="185" r="4" fill={C.primary} className="fl-dot2" />
+      <circle cx="464" cy="198" r="4" fill={C.light} className="fl-dot3" />
     </svg>
   )
 }
 
-// ── SPACE: Shape carousel ── (V1 is the pick)
-function SpaceV1({ size = 40, color = '#3B7BF2' }) {
+function HexAvatar({ size = 80, variant = 1 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="12" cy="12" r="6" fill={color} opacity="0.7" style={{ animation: 'shapeRotate 8s ease-in-out infinite 0s' }} />
-      <rect x="22" y="6" width="12" height="12" rx="2" fill={color} opacity="0.5" style={{ animation: 'shapeRotate 8s ease-in-out infinite 2s' }} />
-      <polygon points="12,28 18,40 6,40" fill={color} opacity="0.4" style={{ animation: 'shapeRotate 8s ease-in-out infinite 4s' }} />
-      <polygon points="28,26 34,32 28,38 22,32" fill={color} opacity="0.6" style={{ animation: 'shapeRotate 8s ease-in-out infinite 6s' }} />
+    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+      <HexContainer />
+      <circle cx="455" cy="175" r="12" stroke={C.light} strokeWidth="2" fill={C.primary} opacity="0.06" className="av-ring2" />
+      <circle cx="452" cy="173" r="2" fill={C.primary} />
+      <circle cx="458" cy="173" r="2" fill={C.primary} />
+      <path d="M451 178Q455 182 459 178" stroke={C.primary} strokeWidth="1.5" strokeLinecap="round" fill="none" />
+      <path d="M442 195Q455 188 468 195" stroke={C.light} strokeWidth="2.5" strokeLinecap="round" fill="none" />
     </svg>
   )
 }
 
-function SpaceV2({ size = 40, color = '#3B7BF2' }) {
+/* ═══ DISPLAY COMPONENTS ═══ */
+function IconRow({ label, description, variants, hexComponent: HexComp, sizes = [16, 24, 32, 40, 64] }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <rect x="4" y="4" width="14" height="14" rx="4" fill={color} opacity="0.8" style={{ animation: 'shapePulse 2s ease-in-out infinite 0s' }} />
-      <rect x="22" y="4" width="14" height="14" rx="4" fill={color} opacity="0.5" style={{ animation: 'shapePulse 2s ease-in-out infinite 0.3s' }} />
-      <rect x="4" y="22" width="14" height="14" rx="4" fill={color} opacity="0.5" style={{ animation: 'shapePulse 2s ease-in-out infinite 0.6s' }} />
-      <rect x="22" y="22" width="14" height="14" rx="4" fill={color} opacity="0.3" style={{ animation: 'shapePulse 2s ease-in-out infinite 0.9s' }} />
-    </svg>
-  )
-}
-
-function SpaceV3({ size = 40, color = '#3B7BF2' }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="20" cy="20" r="3" fill={color} style={{ animation: 'shapePulse 2s ease-in-out infinite' }} />
-      <circle cx="20" cy="6" r="4" fill={color} opacity="0.7" style={{ animation: 'orbitSpin 6s linear infinite' , transformOrigin: '20px 20px' }} />
-      <rect x="30" y="16" width="8" height="8" rx="2" fill={color} opacity="0.5" style={{ animation: 'orbitSpin 6s linear infinite reverse', transformOrigin: '20px 20px' }} />
-      <polygon points="20,34 24,40 16,40" fill={color} opacity="0.4" />
-      <polygon points="4,20 8,16 8,24" fill={color} opacity="0.6" />
-    </svg>
-  )
-}
-
-// ── FLOW: Curved paths with dots ── (V3 is the pick)
-function FlowV1({ size = 40, color = '#6366F1' }) {
-  const lineAnim = (delay) => ({
-    animation: `flowPulse 2s ease-in-out ${delay}s infinite`,
-  })
-  return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <path d="M4 30Q14 10 20 20T36 10" stroke={color} strokeWidth="2.5" strokeLinecap="round" fill="none" style={lineAnim(0)} />
-      <circle cx="4" cy="30" r="3" fill={color} style={{ animation: 'dotPulse 2s ease-in-out infinite 0s' }} />
-      <circle cx="20" cy="20" r="2.5" fill={color} opacity="0.6" style={{ animation: 'dotPulse 2s ease-in-out infinite 0.3s' }} />
-      <circle cx="36" cy="10" r="3" fill={color} style={{ animation: 'dotPulse 2s ease-in-out infinite 0.6s' }} />
-    </svg>
-  )
-}
-
-function FlowV2({ size = 40, color = '#6366F1' }) {
-  const lineAnim = (delay) => ({
-    animation: `flowPulse 2s ease-in-out ${delay}s infinite`,
-  })
-  return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <path d="M4 12Q16 6 36 12" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.4" style={lineAnim(0)} />
-      <path d="M4 20Q16 14 36 20" stroke={color} strokeWidth="2.5" strokeLinecap="round" fill="none" opacity="0.7" style={lineAnim(0.15)} />
-      <path d="M4 28Q16 22 36 28" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.4" style={lineAnim(0.3)} />
-      <circle cx="36" cy="12" r="2.5" fill={color} opacity="0.4" style={{ animation: 'dotPulse 2s ease-in-out infinite 0s' }} />
-      <circle cx="36" cy="20" r="3" fill={color} style={{ animation: 'dotPulse 2s ease-in-out infinite 0.2s' }} />
-      <circle cx="36" cy="28" r="2.5" fill={color} opacity="0.4" style={{ animation: 'dotPulse 2s ease-in-out infinite 0.4s' }} />
-    </svg>
-  )
-}
-
-function FlowV3({ size = 40, color = '#6366F1' }) {
-  const dotAnim = (delay) => ({
-    animation: `dotPulse 2s ease-in-out ${delay}s infinite`,
-  })
-  return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="6" cy="20" r="4" fill={color} style={dotAnim(0)} />
-      <path d="M10 20H18" stroke={color} strokeWidth="2" strokeLinecap="round" style={{ animation: 'flowPulse 2s ease-in-out infinite' }} />
-      <path d="M18 20Q22 20 26 12" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" style={{ animation: 'flowPulse 2s ease-in-out 0.1s infinite' }} />
-      <path d="M18 20Q22 20 26 20" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" style={{ animation: 'flowPulse 2s ease-in-out 0.2s infinite' }} />
-      <path d="M18 20Q22 20 26 28" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" style={{ animation: 'flowPulse 2s ease-in-out 0.3s infinite' }} />
-      <circle cx="30" cy="12" r="3" fill={color} opacity="0.5" style={dotAnim(0.2)} />
-      <circle cx="30" cy="20" r="3" fill={color} opacity="0.7" style={dotAnim(0.4)} />
-      <circle cx="30" cy="28" r="3" fill={color} opacity="0.5" style={dotAnim(0.6)} />
-    </svg>
-  )
-}
-
-// ── AVATAR: New variations ──
-function AvatarV1({ size = 40, color = '#0EA5E9' }) {
-  // Pulsing concentric circles (like a video call ring)
-  return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="20" cy="20" r="16" stroke={color} strokeWidth="1.5" fill="none" opacity="0.15" style={{ animation: 'ringPulse 2s ease-out infinite' }} />
-      <circle cx="20" cy="20" r="11" stroke={color} strokeWidth="1.5" fill="none" opacity="0.3" style={{ animation: 'ringPulse 2s ease-out 0.3s infinite' }} />
-      <circle cx="20" cy="18" r="6" fill={color} opacity="0.12" />
-      <circle cx="18" cy="16.5" r="1.2" fill={color} />
-      <circle cx="22" cy="16.5" r="1.2" fill={color} />
-      <path d="M17 20.5Q20 23 23 20.5" stroke={color} strokeWidth="1.2" strokeLinecap="round" fill="none" />
-      <path d="M12 32Q20 27 28 32" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.4" />
-    </svg>
-  )
-}
-
-function AvatarV2({ size = 40, color = '#0EA5E9' }) {
-  // Waveform + face (speaking avatar)
-  return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="20" cy="16" r="8" fill={color} opacity="0.08" stroke={color} strokeWidth="1.5" />
-      <circle cx="17.5" cy="14.5" r="1.3" fill={color} />
-      <circle cx="22.5" cy="14.5" r="1.3" fill={color} />
-      <path d="M17 19Q20 22 23 19" stroke={color} strokeWidth="1.3" strokeLinecap="round" fill="none" />
-      {/* Speaking waveform below face */}
-      <rect x="11" y="30" width="2.5" height="5" rx="1.25" fill={color} opacity="0.3" style={{ animation: 'waveBar 1s ease-in-out 0s infinite alternate' }} />
-      <rect x="15.5" y="28" width="2.5" height="9" rx="1.25" fill={color} opacity="0.5" style={{ animation: 'waveBar 1s ease-in-out 0.1s infinite alternate' }} />
-      <rect x="20" y="27" width="2.5" height="11" rx="1.25" fill={color} opacity="0.7" style={{ animation: 'waveBar 1s ease-in-out 0.2s infinite alternate' }} />
-      <rect x="24.5" y="29" width="2.5" height="7" rx="1.25" fill={color} opacity="0.5" style={{ animation: 'waveBar 1s ease-in-out 0.3s infinite alternate' }} />
-      <rect x="29" y="31" width="2.5" height="3" rx="1.25" fill={color} opacity="0.3" style={{ animation: 'waveBar 1s ease-in-out 0.4s infinite alternate' }} />
-    </svg>
-  )
-}
-
-function AvatarV3({ size = 40, color = '#0EA5E9' }) {
-  // Glowing orb with face emerging
-  return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="20" cy="20" r="16" fill={color} opacity="0.06" style={{ animation: 'ringPulse 3s ease-out infinite' }} />
-      <circle cx="20" cy="20" r="12" fill={color} opacity="0.08" />
-      <circle cx="20" cy="18" r="7" fill={color} opacity="0.04" stroke={color} strokeWidth="1.2" />
-      <circle cx="17.5" cy="16" r="1.5" fill={color} opacity="0.8" />
-      <circle cx="22.5" cy="16" r="1.5" fill={color} opacity="0.8" />
-      <path d="M17 21Q20 24 23 21" stroke={color} strokeWidth="1.4" strokeLinecap="round" fill="none" />
-    </svg>
-  )
-}
-
-function AvatarV4({ size = 40, color = '#0EA5E9' }) {
-  // Abstract: two overlapping circles (human + AI merging)
-  return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="15" cy="20" r="10" stroke={color} strokeWidth="1.8" fill={color} opacity="0.06" style={{ animation: 'shapePulse 3s ease-in-out infinite' }} />
-      <circle cx="25" cy="20" r="10" stroke={color} strokeWidth="1.8" fill={color} opacity="0.06" style={{ animation: 'shapePulse 3s ease-in-out 0.5s infinite' }} />
-      {/* Face in the overlap zone */}
-      <circle cx="18.5" cy="18" r="1.2" fill={color} />
-      <circle cx="21.5" cy="18" r="1.2" fill={color} />
-      <path d="M18 22Q20 24.5 22 22" stroke={color} strokeWidth="1.2" strokeLinecap="round" fill="none" />
-    </svg>
-  )
-}
-
-// ── DISPLAY COMPONENTS ──
-function IconRow({ label, description, variants, sizes = [16, 24, 32, 40, 64, 80] }) {
-  return (
-    <div className="mb-14">
-      <h3
-        className="text-xl font-bold text-text mb-1 tracking-tight"
-        style={{ fontFamily: 'var(--font-outfit)' }}
-      >
+    <div className="mb-16">
+      <h3 className="text-xl font-bold text-text mb-1 tracking-tight" style={{ fontFamily: 'var(--font-outfit)' }}>
         {label}
       </h3>
       {description && <p className="text-sm text-text-secondary mb-6">{description}</p>}
+
+      {/* Hex version */}
+      {HexComp && (
+        <div className="mb-8">
+          <p className="text-[10px] font-semibold text-text-secondary uppercase tracking-wider mb-3">Hex Logo Version</p>
+          <div className="flex items-end gap-6">
+            <div className="flex flex-col items-center gap-2">
+              <div className="flex items-center justify-center rounded-xl p-3" style={{ background: 'rgba(0,0,0,0.02)', border: '1px solid rgba(0,0,0,0.04)' }}>
+                <HexComp size={100} />
+              </div>
+              <span className="text-[10px] text-text-secondary font-mono">100px hex</span>
+            </div>
+            <div className="flex flex-col items-center gap-2">
+              <div className="flex items-center justify-center rounded-xl p-2" style={{ background: 'rgba(0,0,0,0.02)', border: '1px solid rgba(0,0,0,0.04)' }}>
+                <HexComp size={48} />
+              </div>
+              <span className="text-[10px] text-text-secondary font-mono">48px hex</span>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Accent-only variants */}
       <div className="space-y-8">
-        {variants.map(({ name, Component, color, picked }, vi) => (
+        {variants.map(({ name, Component, picked }, vi) => (
           <div key={vi} className={picked ? 'rounded-2xl p-5 -mx-5' : ''} style={picked ? { background: 'rgba(59,123,242,0.04)', border: '1px solid rgba(59,123,242,0.1)' } : {}}>
             <div className="flex items-center gap-2 mb-3">
-              <p className="text-xs font-semibold text-text-secondary uppercase tracking-wider">
-                Variant {vi + 1}: {name}
-              </p>
+              <p className="text-xs font-semibold text-text-secondary uppercase tracking-wider">V{vi + 1}: {name}</p>
               {picked && <span className="text-[10px] font-bold text-primary bg-primary/10 px-2 py-0.5 rounded-full">PICKED</span>}
             </div>
             <div className="flex items-end gap-6 flex-wrap">
               {sizes.map((s) => (
                 <div key={s} className="flex flex-col items-center gap-2">
-                  <div
-                    className="flex items-center justify-center rounded-xl"
-                    style={{
-                      width: Math.max(s + 16, 40),
-                      height: Math.max(s + 16, 40),
-                      background: 'rgba(0,0,0,0.02)',
-                      border: '1px solid rgba(0,0,0,0.04)',
-                    }}
-                  >
-                    <Component size={s} color={color} />
+                  <div className="flex items-center justify-center rounded-xl"
+                    style={{ width: Math.max(s + 16, 40), height: Math.max(s + 16, 40), background: 'rgba(0,0,0,0.02)', border: '1px solid rgba(0,0,0,0.04)' }}>
+                    <Component size={s} />
                   </div>
                   <span className="text-[10px] text-text-secondary font-mono">{s}px</span>
                 </div>
@@ -347,149 +294,164 @@ function IconRow({ label, description, variants, sizes = [16, 24, 32, 40, 64, 80
   )
 }
 
-// ── PAGE ──
+/* ═══ PAGE ═══ */
 export default function IconExplorationPage() {
   return (
     <div className="min-h-screen bg-bg pt-28 pb-20">
+      {/* All animations using brand blue only */}
       <style jsx global>{`
-        @keyframes waveBar {
-          0% { transform: scaleY(0.6); opacity: 0.4; }
-          100% { transform: scaleY(1); opacity: 1; }
+        /* Receptionist: waveform bars - heartbeat style from original */
+        .rc-bar1 { animation: rcPulse 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center bottom; }
+        .rc-bar2 { animation: rcPulse 10s ease-in-out infinite 0.1s; transform-box: fill-box; transform-origin: center bottom; }
+        .rc-bar3 { animation: rcPulse 10s ease-in-out infinite 0.2s; transform-box: fill-box; transform-origin: center bottom; }
+        .rc-bar4 { animation: rcPulse 10s ease-in-out infinite 0.3s; transform-box: fill-box; transform-origin: center bottom; }
+        .rc-bar5 { animation: rcPulse 10s ease-in-out infinite 0.4s; transform-box: fill-box; transform-origin: center bottom; }
+        .rc-bar6 { animation: rcPulse 10s ease-in-out infinite 0.5s; transform-box: fill-box; transform-origin: center bottom; }
+        @keyframes rcPulse {
+          0%   { opacity: 0.45; transform: scaleY(0.7); }
+          3%   { opacity: 1;    transform: scaleY(1.15); }
+          5%   { opacity: 0.6;  transform: scaleY(0.85); }
+          7%   { opacity: 1;    transform: scaleY(1.05); }
+          10%  { opacity: 0.45; transform: scaleY(0.7); }
+          100% { opacity: 0.45; transform: scaleY(0.7); }
         }
-        @keyframes typingDot {
-          0%, 100% { transform: scale(1); opacity: 0.3; }
-          50% { transform: scale(1.4); opacity: 1; }
+
+        /* Messenger: typing dots - scale pulse from original */
+        .msg-dot1 { animation: msgDot 1.4s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
+        .msg-dot2 { animation: msgDot 1.4s ease-in-out infinite 0.2s; transform-box: fill-box; transform-origin: center; }
+        .msg-dot3 { animation: msgDot 1.4s ease-in-out infinite 0.4s; transform-box: fill-box; transform-origin: center; }
+        @keyframes msgDot {
+          0%, 60%, 100% { transform: scale(1); opacity: 0.35; }
+          30% { transform: scale(1.4); opacity: 1; }
         }
-        @keyframes planeFly {
-          0% { transform: translate(0, 0); }
+
+        /* Outreach: paper plane gentle float */
+        .outreach-plane {
+          animation: planeDrift 3s ease-in-out infinite;
+          transform-box: fill-box;
+          transform-origin: center;
+        }
+        @keyframes planeDrift {
+          0%, 100% { transform: translate(0, 0); }
           50% { transform: translate(3px, -2px); }
-          100% { transform: translate(0, 0); }
         }
-        @keyframes planeDispatch {
-          0% { transform: translate(0, 0) scale(1); opacity: 0.3; }
-          50% { transform: translate(4px, -3px) scale(1.1); opacity: 1; }
-          100% { transform: translate(0, 0) scale(1); opacity: 0.3; }
+
+        /* Space: shapes carousel - each pulses in sequence */
+        .sp-shape1 { animation: spCarousel 16s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
+        .sp-shape2 { animation: spCarousel 16s ease-in-out infinite 4s; transform-box: fill-box; transform-origin: center; }
+        .sp-shape3 { animation: spCarousel 16s ease-in-out infinite 8s; transform-box: fill-box; transform-origin: center; }
+        .sp-shape4 { animation: spCarousel 16s ease-in-out infinite 12s; transform-box: fill-box; transform-origin: center; }
+        @keyframes spCarousel {
+          0%   { opacity: 0.3; transform: scale(0.85); }
+          6%   { opacity: 1;   transform: scale(1.1); }
+          20%  { opacity: 1;   transform: scale(1); }
+          25%  { opacity: 0.3; transform: scale(0.85); }
+          100% { opacity: 0.3; transform: scale(0.85); }
         }
-        @keyframes shapeRotate {
-          0%, 100% { transform: scale(1); opacity: 0.5; }
-          25% { transform: scale(1.15); opacity: 1; }
-          50% { transform: scale(1); opacity: 0.5; }
+
+        /* Flow: branching lines + dots pulse */
+        .fl-dot-in { animation: flDotPulse 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
+        .fl-dot1 { animation: flDotPulse 10s ease-in-out infinite 0.2s; transform-box: fill-box; transform-origin: center; }
+        .fl-dot2 { animation: flDotPulse 10s ease-in-out infinite 0.4s; transform-box: fill-box; transform-origin: center; }
+        .fl-dot3 { animation: flDotPulse 10s ease-in-out infinite 0.6s; transform-box: fill-box; transform-origin: center; }
+        .fl-line, .fl-branch1, .fl-branch2, .fl-branch3 { animation: flLinePulse 10s ease-in-out infinite; }
+        @keyframes flDotPulse {
+          0%   { opacity: 0.35; transform: scale(1); }
+          3%   { opacity: 1;    transform: scale(1.3); }
+          5%   { opacity: 0.5;  transform: scale(1); }
+          7%   { opacity: 1;    transform: scale(1.2); }
+          10%  { opacity: 0.35; transform: scale(1); }
+          100% { opacity: 0.35; transform: scale(1); }
         }
-        @keyframes shapePulse {
-          0%, 100% { transform: scale(1); opacity: 0.7; }
-          50% { transform: scale(1.08); opacity: 1; }
+        @keyframes flLinePulse {
+          0%   { opacity: 0.3; stroke: ${C.light}; }
+          3%   { opacity: 1;   stroke: ${C.dark}; }
+          5%   { opacity: 0.4; stroke: ${C.light}; }
+          7%   { opacity: 0.9; stroke: ${C.dark}; }
+          10%  { opacity: 0.3; stroke: ${C.light}; }
+          100% { opacity: 0.3; stroke: ${C.light}; }
         }
-        @keyframes flowPulse {
-          0%, 100% { opacity: 0.4; }
-          50% { opacity: 1; }
+
+        /* Avatar: rings pulse */
+        .av-ring1 { animation: avRing 3s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+        .av-ring2 { animation: avRing 3s ease-in-out 0.5s infinite; transform-box: fill-box; transform-origin: center; }
+        @keyframes avRing {
+          0%, 100% { opacity: 0.15; transform: scale(0.97); }
+          50% { opacity: 0.4; transform: scale(1.03); }
         }
-        @keyframes dotPulse {
-          0%, 100% { transform: scale(1); opacity: 0.5; }
-          50% { transform: scale(1.25); opacity: 1; }
-        }
-        @keyframes ringPulse {
-          0% { transform: scale(0.95); opacity: 0.3; }
-          50% { transform: scale(1.05); opacity: 0.15; }
-          100% { transform: scale(0.95); opacity: 0.3; }
-        }
-        @keyframes orbitSpin {
-          0% { transform: rotate(0deg); }
-          100% { transform: rotate(360deg); }
+        .av-merge1 { animation: avMerge 4s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+        .av-merge2 { animation: avMerge 4s ease-in-out 2s infinite; transform-box: fill-box; transform-origin: center; }
+        @keyframes avMerge {
+          0%, 100% { opacity: 0.04; transform: scale(1); }
+          50% { opacity: 0.12; transform: scale(1.05); }
         }
       `}</style>
 
       <div className="max-w-6xl mx-auto px-6">
-
         <AnimatedSection>
-          <Badge variant="blue" className="mb-4">Design Exploration</Badge>
-          <h1
-            className="text-4xl font-extrabold text-text tracking-tight mb-3"
-            style={{ fontFamily: 'var(--font-outfit)' }}
-          >
-            Product Icon Family (Animated)
+          <Badge variant="blue" className="mb-4">Design Exploration v2</Badge>
+          <h1 className="text-4xl font-extrabold text-text tracking-tight mb-3" style={{ fontFamily: 'var(--font-outfit)' }}>
+            Product Icon Family (Animated + Hex)
           </h1>
           <p className="text-text-secondary max-w-2xl mb-2">
-            Accent-forward animated icons. Each reflects its product's hex accent theme.
-            Picked variants are highlighted. Avatar has 4 new variations.
-          </p>
-          <p className="text-xs text-text-secondary">
-            Internal design review only. Not indexed.
+            All icons use unified brand blue (#3B7BF2 / #6B9AEA / #2D6AE0).
+            Animations match the original hex accent patterns (10s cycle, brief burst then rest).
+            Each product shows: hex logo version + accent-only variants at multiple sizes.
           </p>
         </AnimatedSection>
 
         <div className="gradient-divider my-10" />
 
-        <IconRow
-          label="Receptionist"
-          description="Voice/audio waveform. Undecided, review all three with animation."
+        <IconRow label="Receptionist" description="Voice waveform bars. Undecided. All three use the same heartbeat animation pattern." hexComponent={HexReceptionist}
           variants={[
-            { name: 'Symmetric 5-bar waveform', Component: ReceptionistV1, color: '#3B7BF2' },
-            { name: 'Thin symmetric 5-bar', Component: ReceptionistV2, color: '#3B7BF2' },
-            { name: 'Asymmetric 6-bar waveform', Component: ReceptionistV3, color: '#3B7BF2' },
+            { name: 'Symmetric 5-bar', Component: ReceptionistV1 },
+            { name: 'Thin 5-bar', Component: ReceptionistV2 },
+            { name: 'Asymmetric 6-bar', Component: ReceptionistV3 },
           ]}
         />
 
         <div className="gradient-divider my-10" />
 
-        <IconRow
-          label="Messenger"
-          description="Chat typing indicator. V2 picked."
+        <IconRow label="Messenger" description="Typing indicator dots. V2 picked." hexComponent={HexMessenger}
           variants={[
-            { name: 'Ascending hollow circles', Component: MessengerV1, color: '#6366F1' },
-            { name: 'Three inline dots (typing)', Component: MessengerV2, color: '#6366F1', picked: true },
-            { name: 'Chat bubble with dots', Component: MessengerV3, color: '#6366F1' },
+            { name: 'Three inline dots (scale pulse)', Component: MessengerV2, picked: true },
           ]}
         />
 
         <div className="gradient-divider my-10" />
 
-        <IconRow
-          label="Outreach"
-          description="Message dispatched outward. V1 picked."
+        <IconRow label="Outreach" description="Paper plane. V1 picked." hexComponent={HexOutreach}
           variants={[
-            { name: 'Single paper plane', Component: OutreachV1, color: '#0EA5E9', picked: true },
-            { name: 'Three planes dispatching', Component: OutreachV2, color: '#0EA5E9' },
-            { name: 'Bold send arrow', Component: OutreachV3, color: '#0EA5E9' },
+            { name: 'Single paper plane (gentle drift)', Component: OutreachV1, picked: true },
           ]}
         />
 
         <div className="gradient-divider my-10" />
 
-        <IconRow
-          label="Space"
-          description="Multi-tool workspace. V1 picked."
+        <IconRow label="Space" description="Multi-tool shapes carousel. V1 picked." hexComponent={HexSpace}
           variants={[
-            { name: 'Mixed shapes (circle, square, triangle, diamond)', Component: SpaceV1, color: '#3B7BF2', picked: true },
-            { name: '2x2 rounded grid', Component: SpaceV2, color: '#3B7BF2' },
-            { name: 'Shapes orbiting center', Component: SpaceV3, color: '#3B7BF2' },
+            { name: 'Mixed shapes (circle, square, triangle, diamond)', Component: SpaceV1, picked: true },
           ]}
         />
 
         <div className="gradient-divider my-10" />
 
-        <IconRow
-          label="Flow"
-          description="Data flowing through connected paths. V3 picked."
+        <IconRow label="Flow" description="Branching data flow. V3 picked." hexComponent={HexFlow}
           variants={[
-            { name: 'S-curve with endpoint dots', Component: FlowV1, color: '#6366F1' },
-            { name: 'Three parallel flow lines', Component: FlowV2, color: '#6366F1' },
-            { name: 'Branching flow (1 to 3)', Component: FlowV3, color: '#6366F1', picked: true },
+            { name: 'Branching flow (1 to 3) with pulsing dots', Component: FlowV3, picked: true },
           ]}
         />
 
         <div className="gradient-divider my-10" />
 
-        <IconRow
-          label="Avatar"
-          description="Human-like AI presence. 4 new variations. None picked yet."
+        <IconRow label="Avatar" description="Human-like AI presence. 4 variations. None picked yet." hexComponent={HexAvatar}
           variants={[
-            { name: 'Pulsing rings + face (video call)', Component: AvatarV1, color: '#0EA5E9' },
-            { name: 'Face + speaking waveform', Component: AvatarV2, color: '#0EA5E9' },
-            { name: 'Glowing orb with face', Component: AvatarV3, color: '#0EA5E9' },
-            { name: 'Two merging circles + face (human meets AI)', Component: AvatarV4, color: '#0EA5E9' },
+            { name: 'Pulsing rings + face (video call)' , Component: AvatarV1 },
+            { name: 'Face + speaking waveform bars', Component: AvatarV2 },
+            { name: 'Glowing orb with face', Component: AvatarV3 },
+            { name: 'Two merging circles (human meets AI)', Component: AvatarV4 },
           ]}
         />
-
       </div>
     </div>
   )

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -97,24 +97,18 @@ function SpaceV1({ size = 40 }) {
   )
 }
 
-/* ── FLOW: Horizontal branch, rotated 45deg, data travels from input to outputs ── */
+/* ── FLOW: Curved branches like git-branch, rotated 45deg ── */
 function FlowV3({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none" style={{ transform: 'rotate(-45deg)' }}>
-      {/* Input dot */}
-      <circle cx="6" cy="20" r="4" fill="#3B7BF2" className="fl-src" />
-      {/* Main line */}
-      <path d="M10 20H18" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line" />
-      {/* Branches */}
-      <path d="M18 20L30 12" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b1" />
-      <path d="M18 20L30 20" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b2" />
-      <path d="M18 20L30 28" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b3" />
-      {/* Output dots - always visible at baseline */}
-      <circle cx="32" cy="12" r="3" fill="#6B9AEA" className="fl-out fl-out1" />
-      <circle cx="32" cy="20" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
-      <circle cx="32" cy="28" r="3" fill="#6B9AEA" className="fl-out fl-out3" />
-      {/* Traveling packet */}
-      <circle r="2" fill="#2D6AE0" className="fl-packet" />
+      {/* Three curved flow lines (Q = quadratic bezier, like the original hex) */}
+      <path d="M4 30 Q14 10 24 18" fill="none" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
+      <path d="M10 28 Q20 12 32 16" fill="none" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl-b2" />
+      <path d="M16 32 Q26 18 36 22" fill="none" stroke="#6B9AEA" strokeWidth="1.5" strokeLinecap="round" className="fl-line fl-b3" />
+      {/* Endpoint dots */}
+      <circle cx="4" cy="30" r="3.5" fill="#6B9AEA" className="fl-out fl-out1" />
+      <circle cx="24" cy="18" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
+      <circle cx="36" cy="22" r="3.5" fill="#6B9AEA" className="fl-out fl-out3" />
     </svg>
   )
 }

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -160,9 +160,8 @@ function AvatarV4({ size = 40 }) {
 
 /* ═══ HEX VERSIONS: Show accent inside subtle hex outline ═══ */
 function HexReceptionist({ size = 80 }) {
-  const s = size / 80
   return (
-    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+    <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
       <rect x="424.5" y="188" width="5" height="14" rx="2.5" fill={C.light} className="rc-bar1" />
       <rect x="435.5" y="178" width="5" height="24" rx="2.5" fill={C.primary} className="rc-bar2" />
@@ -175,7 +174,7 @@ function HexReceptionist({ size = 80 }) {
 
 function HexMessenger({ size = 80 }) {
   return (
-    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+    <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
       <circle cx="430" cy="197" r="5" fill={C.primary} className="msg-dot1" />
       <circle cx="455" cy="187" r="7" fill={C.primary} className="msg-dot2" />
@@ -186,7 +185,7 @@ function HexMessenger({ size = 80 }) {
 
 function HexOutreach({ size = 80 }) {
   return (
-    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+    <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
       <g className="outreach-plane">
         <path d="M430 190l35-16-10 18-7-4-18 2z" fill={C.primary} opacity="0.12" />
@@ -199,7 +198,7 @@ function HexOutreach({ size = 80 }) {
 
 function HexSpace({ size = 80 }) {
   return (
-    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+    <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
       <circle cx="440" cy="175" r="7" fill={C.primary} className="sp-shape1" />
       <rect x="455" y="168" width="14" height="14" rx="2" fill={C.primary} className="sp-shape2" />
@@ -211,7 +210,7 @@ function HexSpace({ size = 80 }) {
 
 function HexFlow({ size = 80 }) {
   return (
-    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+    <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
       <circle cx="425" cy="185" r="5" fill={C.primary} className="fl-dot-in" />
       <path d="M430 185H445" stroke={C.primary} strokeWidth="2.5" strokeLinecap="round" className="fl-line" />
@@ -227,7 +226,7 @@ function HexFlow({ size = 80 }) {
 
 function HexAvatar({ size = 80, variant = 1 }) {
   return (
-    <svg width={size} height={size * 0.87} viewBox="220 130 320 280">
+    <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
       <circle cx="455" cy="175" r="12" stroke={C.light} strokeWidth="2" fill={C.primary} opacity="0.06" className="av-ring2" />
       <circle cx="452" cy="173" r="2" fill={C.primary} />

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -4,21 +4,22 @@ import { AnimatedSection } from '@/components/ui/AnimatedSection'
 import { Badge } from '@/components/ui/Badge'
 import { HexContainer } from '@/components/ui/Logo'
 
-/* ─────────────────────────────────────────────────
-   UNIFIED COLOR: All icons use brand blue family
-   Primary: #3B7BF2  Light: #6B9AEA  Dark: #2D6AE0
-───────────────────────────────────────────────────── */
-const C = { primary: '#3B7BF2', light: '#6B9AEA', dark: '#2D6AE0' }
+/* ═══════════════════════════════════════════════════
+   PRODUCT ICON EXPLORATION v3
+   - Unified brand blue (#3B7BF2 / #6B9AEA / #2D6AE0)
+   - 10s heartbeat cycle (burst first 10%, rest 90%)
+   - Animations match original hex accent quality
+═══════════════════════════════════════════════════ */
 
-/* ═══ RECEPTIONIST: Waveform bars ═══ */
+/* ── RECEPTIONIST: Waveform bars ── */
 function ReceptionistV1({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <rect x="4" y="16" width="5" height="8" rx="2.5" fill={C.light} className="rc-bar1" />
-      <rect x="11" y="10" width="5" height="20" rx="2.5" fill={C.primary} className="rc-bar2" />
-      <rect x="18" y="6" width="5" height="28" rx="2.5" fill={C.dark} className="rc-bar3" />
-      <rect x="25" y="12" width="5" height="16" rx="2.5" fill={C.primary} className="rc-bar4" />
-      <rect x="32" y="14" width="5" height="12" rx="2.5" fill={C.light} className="rc-bar5" />
+      <rect x="4" y="16" width="5" height="8" rx="2.5" fill="#6B9AEA" className="vb vb1" />
+      <rect x="11" y="10" width="5" height="20" rx="2.5" fill="#6B9AEA" className="vb vb2" />
+      <rect x="18" y="6" width="5" height="28" rx="2.5" fill="#6B9AEA" className="vb vb3" />
+      <rect x="25" y="12" width="5" height="16" rx="2.5" fill="#6B9AEA" className="vb vb4" />
+      <rect x="32" y="14" width="5" height="12" rx="2.5" fill="#6B9AEA" className="vb vb5" />
     </svg>
   )
 }
@@ -26,11 +27,11 @@ function ReceptionistV1({ size = 40 }) {
 function ReceptionistV2({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <rect x="6" y="18" width="4" height="4" rx="2" fill={C.light} className="rc-bar1" />
-      <rect x="13" y="12" width="4" height="16" rx="2" fill={C.light} className="rc-bar2" />
-      <rect x="20" y="6" width="4" height="28" rx="2" fill={C.primary} className="rc-bar3" />
-      <rect x="27" y="10" width="4" height="20" rx="2" fill={C.light} className="rc-bar4" />
-      <rect x="34" y="16" width="4" height="8" rx="2" fill={C.light} className="rc-bar5" />
+      <rect x="6" y="18" width="4" height="4" rx="2" fill="#6B9AEA" className="vb vb1" />
+      <rect x="13" y="12" width="4" height="16" rx="2" fill="#6B9AEA" className="vb vb2" />
+      <rect x="20" y="6" width="4" height="28" rx="2" fill="#6B9AEA" className="vb vb3" />
+      <rect x="27" y="10" width="4" height="20" rx="2" fill="#6B9AEA" className="vb vb4" />
+      <rect x="34" y="16" width="4" height="8" rx="2" fill="#6B9AEA" className="vb vb5" />
     </svg>
   )
 }
@@ -38,136 +39,158 @@ function ReceptionistV2({ size = 40 }) {
 function ReceptionistV3({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <rect x="5" y="17" width="3.5" height="6" rx="1.75" fill={C.light} className="rc-bar1" />
-      <rect x="11" y="12" width="3.5" height="16" rx="1.75" fill={C.light} className="rc-bar2" />
-      <rect x="17" y="7" width="4" height="26" rx="2" fill={C.primary} className="rc-bar3" />
-      <rect x="23.5" y="9" width="3.5" height="22" rx="1.75" fill={C.primary} className="rc-bar4" />
-      <rect x="29.5" y="13" width="3.5" height="14" rx="1.75" fill={C.light} className="rc-bar5" />
-      <rect x="35.5" y="17" width="3.5" height="6" rx="1.75" fill={C.light} className="rc-bar6" />
+      <rect x="3" y="17" width="3.5" height="6" rx="1.75" fill="#6B9AEA" className="vb vb1" />
+      <rect x="9" y="12" width="3.5" height="16" rx="1.75" fill="#6B9AEA" className="vb vb2" />
+      <rect x="15" y="7" width="4" height="26" rx="2" fill="#6B9AEA" className="vb vb3" />
+      <rect x="21.5" y="9" width="3.5" height="22" rx="1.75" fill="#6B9AEA" className="vb vb4" />
+      <rect x="27.5" y="13" width="3.5" height="14" rx="1.75" fill="#6B9AEA" className="vb vb5" />
+      <rect x="33.5" y="17" width="3.5" height="6" rx="1.75" fill="#6B9AEA" className="vb vb6" />
     </svg>
   )
 }
 
-/* ═══ MESSENGER: Typing dots (V2 picked) ═══ */
+/* ── MESSENGER: Three dots scale pulse (PICKED) ── */
 function MessengerV2({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="10" cy="20" r="3" fill={C.primary} className="msg-dot1" />
-      <circle cx="20" cy="20" r="3" fill={C.primary} className="msg-dot2" />
-      <circle cx="30" cy="20" r="3" fill={C.primary} className="msg-dot3" />
+      <circle cx="10" cy="20" r="3.5" fill="#3B7BF2" className="md md1" />
+      <circle cx="20" cy="20" r="3.5" fill="#3B7BF2" className="md md2" />
+      <circle cx="30" cy="20" r="3.5" fill="#3B7BF2" className="md md3" />
     </svg>
   )
 }
 
-/* ═══ OUTREACH: Paper plane (V1 picked) ═══ */
+/* ── OUTREACH: Paper plane with flight trajectory (PICKED) ── */
 function OutreachV1({ size = 40 }) {
   return (
-    <svg width={size} height={size} viewBox="0 0 40 40" fill="none" className="outreach-plane">
-      <path d="M6 20l28-14-8 16-6-4-14 2z" fill={C.primary} opacity="0.12" />
-      <path d="M6 20l28-14-8 16-6-4-14 2z" stroke={C.primary} strokeWidth="1.8" strokeLinejoin="round" fill="none" />
-      <path d="M20 18l6 14" stroke={C.primary} strokeWidth="1.5" strokeLinecap="round" />
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <g className="pp pp1">
+        <path d="M26 16L8 14l8 10-2 10z" fill="#3B7BF2" />
+      </g>
+      <g className="pp pp2">
+        <path d="M26 16L8 14l8 10-2 10z" fill="#3B7BF2" />
+      </g>
+      <g className="pp pp3">
+        <path d="M26 16L8 14l8 10-2 10z" fill="#3B7BF2" />
+      </g>
     </svg>
   )
 }
 
-/* ═══ SPACE: Mixed shapes (V1 picked) ═══ */
+/* ── SPACE: Shape carousel, one at a time (PICKED) ── */
 function SpaceV1({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="12" cy="12" r="6" fill={C.primary} className="sp-shape1" />
-      <rect x="22" y="6" width="12" height="12" rx="2" fill={C.primary} className="sp-shape2" />
-      <polygon points="12,28 18,40 6,40" fill={C.primary} className="sp-shape3" />
-      <polygon points="28,26 34,32 28,38 22,32" fill={C.primary} className="sp-shape4" />
+      <circle cx="20" cy="20" r="8" fill="#3B7BF2" className="cs cs-circle" />
+      <polygon points="20,12 28,20 20,28 12,20" fill="#3B7BF2" className="cs cs-diamond" />
+      <polygon points="20,12 28,28 12,28" fill="#3B7BF2" className="cs cs-triangle" />
+      <rect x="12" y="12" width="16" height="16" rx="2" fill="#3B7BF2" className="cs cs-square" />
     </svg>
   )
 }
 
-/* ═══ FLOW: Branching (V3 picked) ═══ */
+/* ── FLOW: Branching with data flowing from input to outputs (PICKED) ──
+   Aligned diagonally (parallel to hex gap), dot travels from source to targets */
 function FlowV3({ size = 40 }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="6" cy="20" r="4" fill={C.primary} className="fl-dot-in" />
-      <path d="M10 20H18" stroke={C.primary} strokeWidth="2" strokeLinecap="round" className="fl-line" />
-      <path d="M18 20Q22 20 26 12" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch1" />
-      <path d="M18 20Q22 20 26 20" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch2" />
-      <path d="M18 20Q22 20 26 28" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch3" />
-      <circle cx="30" cy="12" r="3" fill={C.light} className="fl-dot1" />
-      <circle cx="30" cy="20" r="3" fill={C.primary} className="fl-dot2" />
-      <circle cx="30" cy="28" r="3" fill={C.light} className="fl-dot3" />
+      {/* Static structure: branches */}
+      <path d="M8 28L18 20" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl1" />
+      <path d="M18 20L32 10" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl2" />
+      <path d="M18 20L32 20" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl2" />
+      <path d="M18 20L32 30" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl3" />
+      {/* Source dot */}
+      <circle cx="8" cy="28" r="4" fill="#3B7BF2" className="fl-src" />
+      {/* Junction dot */}
+      <circle cx="18" cy="20" r="3" fill="#6B9AEA" className="fl-junc" />
+      {/* Target dots */}
+      <circle cx="32" cy="10" r="3" fill="#6B9AEA" className="fl-out fl-out1" />
+      <circle cx="32" cy="20" r="3" fill="#6B9AEA" className="fl-out fl-out2" />
+      <circle cx="32" cy="30" r="3" fill="#6B9AEA" className="fl-out fl-out3" />
+      {/* Traveling data packet */}
+      <circle cx="8" cy="28" r="2" fill="#2D6AE0" className="fl-packet" />
     </svg>
   )
 }
 
-/* ═══ AVATAR: New variations ═══ */
+/* ── AVATAR: New variations ── */
 function AvatarV1({ size = 40 }) {
-  // Pulsing rings + face
+  // Pulsing concentric rings + face (incoming video call)
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="20" cy="20" r="16" stroke={C.light} strokeWidth="1.2" fill="none" className="av-ring1" />
-      <circle cx="20" cy="20" r="11" stroke={C.primary} strokeWidth="1.2" fill="none" className="av-ring2" />
-      <circle cx="20" cy="18" r="6" fill={C.primary} opacity="0.08" />
-      <circle cx="18" cy="16.5" r="1.2" fill={C.primary} />
-      <circle cx="22" cy="16.5" r="1.2" fill={C.primary} />
-      <path d="M17 20.5Q20 23 23 20.5" stroke={C.primary} strokeWidth="1.2" strokeLinecap="round" fill="none" />
-      <path d="M12 32Q20 27 28 32" stroke={C.light} strokeWidth="2" strokeLinecap="round" fill="none" />
+      <circle cx="20" cy="18" r="17" stroke="#6B9AEA" strokeWidth="1" fill="none" className="av-ring av-ring1" />
+      <circle cx="20" cy="18" r="12" stroke="#6B9AEA" strokeWidth="1.2" fill="none" className="av-ring av-ring2" />
+      <circle cx="20" cy="16" r="6" fill="#3B7BF2" opacity="0.08" />
+      <circle cx="18" cy="14.5" r="1.3" fill="#3B7BF2" />
+      <circle cx="22" cy="14.5" r="1.3" fill="#3B7BF2" />
+      <path d="M17 18.5Q20 21 23 18.5" stroke="#3B7BF2" strokeWidth="1.3" strokeLinecap="round" fill="none" />
+      <path d="M11 32Q20 26 29 32" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" fill="none" />
     </svg>
   )
 }
 
 function AvatarV2({ size = 40 }) {
-  // Face + speaking waveform
+  // Face with speaking waveform below (AI that talks face to face)
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="20" cy="16" r="8" fill={C.primary} opacity="0.06" stroke={C.primary} strokeWidth="1.5" />
-      <circle cx="17.5" cy="14.5" r="1.3" fill={C.primary} />
-      <circle cx="22.5" cy="14.5" r="1.3" fill={C.primary} />
-      <path d="M17 19Q20 22 23 19" stroke={C.primary} strokeWidth="1.3" strokeLinecap="round" fill="none" />
-      <rect x="11" y="30" width="2.5" height="5" rx="1.25" fill={C.light} className="rc-bar1" />
-      <rect x="15.5" y="28" width="2.5" height="9" rx="1.25" fill={C.primary} className="rc-bar2" />
-      <rect x="20" y="27" width="2.5" height="11" rx="1.25" fill={C.dark} className="rc-bar3" />
-      <rect x="24.5" y="29" width="2.5" height="7" rx="1.25" fill={C.primary} className="rc-bar4" />
-      <rect x="29" y="31" width="2.5" height="3" rx="1.25" fill={C.light} className="rc-bar5" />
+      <circle cx="20" cy="14" r="8" fill="#3B7BF2" opacity="0.06" stroke="#3B7BF2" strokeWidth="1.2" />
+      <circle cx="17.5" cy="12.5" r="1.3" fill="#3B7BF2" />
+      <circle cx="22.5" cy="12.5" r="1.3" fill="#3B7BF2" />
+      <path d="M17 17Q20 20 23 17" stroke="#3B7BF2" strokeWidth="1.3" strokeLinecap="round" fill="none" />
+      {/* Speaking waveform */}
+      <rect x="10" y="28" width="2.5" height="6" rx="1.25" fill="#6B9AEA" className="vb vb1" />
+      <rect x="15" y="26" width="2.5" height="10" rx="1.25" fill="#6B9AEA" className="vb vb2" />
+      <rect x="20" y="25" width="2.5" height="12" rx="1.25" fill="#6B9AEA" className="vb vb3" />
+      <rect x="25" y="27" width="2.5" height="8" rx="1.25" fill="#6B9AEA" className="vb vb4" />
+      <rect x="30" y="29" width="2.5" height="4" rx="1.25" fill="#6B9AEA" className="vb vb5" />
     </svg>
   )
 }
 
 function AvatarV3({ size = 40 }) {
-  // Glowing orb with face
+  // Ascending dots (like parent brand) but with a face formed by the top dot
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="20" cy="20" r="16" fill={C.primary} opacity="0.04" className="av-ring1" />
-      <circle cx="20" cy="20" r="12" fill={C.primary} opacity="0.06" />
-      <circle cx="20" cy="18" r="7" fill={C.primary} opacity="0.04" stroke={C.primary} strokeWidth="1.2" />
-      <circle cx="17.5" cy="16" r="1.5" fill={C.primary} opacity="0.8" />
-      <circle cx="22.5" cy="16" r="1.5" fill={C.primary} opacity="0.8" />
-      <path d="M17 21Q20 24 23 21" stroke={C.primary} strokeWidth="1.4" strokeLinecap="round" fill="none" />
+      {/* Body circle (largest, bottom) */}
+      <circle cx="20" cy="30" r="8" fill="#3B7BF2" opacity="0.08" stroke="#6B9AEA" strokeWidth="1.5" className="hb hb1" />
+      {/* Torso (medium) */}
+      <circle cx="20" cy="19" r="5" fill="#3B7BF2" opacity="0.1" stroke="#6B9AEA" strokeWidth="1.5" className="hb hb2" />
+      {/* Head (smallest, top) with face */}
+      <circle cx="20" cy="10" r="6" fill="#3B7BF2" opacity="0.06" stroke="#3B7BF2" strokeWidth="1.5" className="hb hb3" />
+      <circle cx="18" cy="9" r="1" fill="#3B7BF2" />
+      <circle cx="22" cy="9" r="1" fill="#3B7BF2" />
+      <path d="M18 12Q20 14 22 12" stroke="#3B7BF2" strokeWidth="1" strokeLinecap="round" fill="none" />
     </svg>
   )
 }
 
 function AvatarV4({ size = 40 }) {
-  // Two merging circles (human meets AI)
+  // Video screen frame with face + live indicator
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="15" cy="20" r="10" stroke={C.light} strokeWidth="1.5" fill={C.primary} opacity="0.04" className="av-merge1" />
-      <circle cx="25" cy="20" r="10" stroke={C.light} strokeWidth="1.5" fill={C.primary} opacity="0.04" className="av-merge2" />
-      <circle cx="18.5" cy="18" r="1.2" fill={C.primary} />
-      <circle cx="21.5" cy="18" r="1.2" fill={C.primary} />
-      <path d="M18 22Q20 24.5 22 22" stroke={C.primary} strokeWidth="1.2" strokeLinecap="round" fill="none" />
+      <rect x="4" y="6" width="32" height="22" rx="4" stroke="#6B9AEA" strokeWidth="1.5" fill="#3B7BF2" opacity="0.04" />
+      <circle cx="20" cy="14" r="5" fill="#3B7BF2" opacity="0.08" stroke="#3B7BF2" strokeWidth="1" />
+      <circle cx="18.5" cy="13" r="1" fill="#3B7BF2" />
+      <circle cx="21.5" cy="13" r="1" fill="#3B7BF2" />
+      <path d="M18 16.5Q20 18.5 22 16.5" stroke="#3B7BF2" strokeWidth="1" strokeLinecap="round" fill="none" />
+      {/* Live dot */}
+      <circle cx="32" cy="10" r="2" fill="#2D6AE0" className="av-live" />
+      {/* Bottom bar (call controls hint) */}
+      <rect x="12" y="32" width="16" height="3" rx="1.5" fill="#6B9AEA" opacity="0.3" />
     </svg>
   )
 }
 
-/* ═══ HEX VERSIONS: Show accent inside subtle hex outline ═══ */
+/* ── HEX VERSIONS ── */
 function HexReceptionist({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      <rect x="424.5" y="188" width="5" height="14" rx="2.5" fill={C.light} className="rc-bar1" />
-      <rect x="435.5" y="178" width="5" height="24" rx="2.5" fill={C.primary} className="rc-bar2" />
-      <rect x="446.5" y="170" width="5" height="30" rx="2.5" fill={C.dark} className="rc-bar3" />
-      <rect x="457.5" y="170" width="5" height="20" rx="2.5" fill={C.primary} className="rc-bar4" />
-      <rect x="468.5" y="167" width="5" height="16" rx="2.5" fill={C.light} className="rc-bar5" />
+      <rect x="424.5" y="188" width="5" height="14" rx="2.5" fill="#6B9AEA" className="vb vb1" />
+      <rect x="435.5" y="178" width="5" height="24" rx="2.5" fill="#6B9AEA" className="vb vb2" />
+      <rect x="446.5" y="170" width="5" height="30" rx="2.5" fill="#6B9AEA" className="vb vb3" />
+      <rect x="457.5" y="170" width="5" height="20" rx="2.5" fill="#6B9AEA" className="vb vb4" />
+      <rect x="468.5" y="167" width="5" height="16" rx="2.5" fill="#6B9AEA" className="vb vb5" />
     </svg>
   )
 }
@@ -176,9 +199,15 @@ function HexMessenger({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      <circle cx="430" cy="197" r="5" fill={C.primary} className="msg-dot1" />
-      <circle cx="455" cy="187" r="7" fill={C.primary} className="msg-dot2" />
-      <circle cx="485" cy="177" r="9" fill={C.primary} className="msg-dot3" />
+      <g className="hb hb1" fill="none" stroke="#6B9AEA" strokeWidth="2" opacity="0.45">
+        <path d="M424.23 202.37 c-2.05 -1.83 -2.42 -2.64 -2.42 -5.42 0 -4.18 2.05 -7.11 5.94 -8.50 2.57 -0.88 3.22 -0.88 5.57 0.22 3.37 1.61 5.35 5.42 4.62 9.02 -1.25 6.60 -8.80 9.09 -13.71 4.69z" />
+      </g>
+      <g className="hb hb2" fill="none" stroke="#6B9AEA" strokeWidth="2" opacity="0.45">
+        <path d="M453.70 193.35 c-4.54 -2.35 -6.60 -5.64 -6.60 -10.63 0 -7.48 3.52 -11.29 11.73 -12.75 10.70 -1.83 17.22 11.80 9.82 20.60 -3.81 4.47 -9.53 5.50 -14.95 2.79z" />
+      </g>
+      <g className="hb hb3" fill="none" stroke="#6B9AEA" strokeWidth="2" opacity="0.45">
+        <path d="M491.08 180.60 c-6.16 -2.64 -9.53 -8.06 -9.53 -15.32 0 -10.41 7.33 -17.88 17.44 -17.96 9.68 0 16.27 6.67 16.27 16.49 0 7.18 -3.81 13.12 -10.41 16.56 -3.30 1.69 -10.11 1.83 -13.78 0.22z" />
+      </g>
     </svg>
   )
 }
@@ -187,10 +216,14 @@ function HexOutreach({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      <g className="outreach-plane">
-        <path d="M430 190l35-16-10 18-7-4-18 2z" fill={C.primary} opacity="0.12" />
-        <path d="M430 190l35-16-10 18-7-4-18 2z" stroke={C.primary} strokeWidth="2" strokeLinejoin="round" fill="none" />
-        <path d="M448 188l6 14" stroke={C.primary} strokeWidth="1.8" strokeLinecap="round" />
+      <g className="pp pp1" fill="#3B7BF2" opacity="0">
+        <path d="M474 174 L450 171 L457 183 L450 195 Z" />
+      </g>
+      <g className="pp pp2" fill="#3B7BF2" opacity="0">
+        <path d="M474 174 L450 171 L457 183 L450 195 Z" />
+      </g>
+      <g className="pp pp3" fill="#3B7BF2" opacity="0">
+        <path d="M474 174 L450 171 L457 183 L450 195 Z" />
       </g>
     </svg>
   )
@@ -200,10 +233,10 @@ function HexSpace({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      <circle cx="440" cy="175" r="7" fill={C.primary} className="sp-shape1" />
-      <rect x="455" y="168" width="14" height="14" rx="2" fill={C.primary} className="sp-shape2" />
-      <polygon points="440,190 447,203 433,203" fill={C.primary} className="sp-shape3" />
-      <polygon points="462,190 469,197 462,204 455,197" fill={C.primary} className="sp-shape4" />
+      <g className="cs cs-circle" opacity="0"><circle cx="458" cy="183" r="10" fill="#3B7BF2" /></g>
+      <g className="cs cs-diamond" opacity="0"><polygon points="458,172 468,183 458,194 448,183" fill="#3B7BF2" /></g>
+      <g className="cs cs-triangle" opacity="0"><polygon points="458,172 470,194 446,194" fill="#3B7BF2" /></g>
+      <g className="cs cs-square" opacity="0"><rect x="448" y="173" width="20" height="20" rx="2" fill="#3B7BF2" /></g>
     </svg>
   )
 }
@@ -212,62 +245,50 @@ function HexFlow({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      <circle cx="425" cy="185" r="5" fill={C.primary} className="fl-dot-in" />
-      <path d="M430 185H445" stroke={C.primary} strokeWidth="2.5" strokeLinecap="round" className="fl-line" />
-      <path d="M445 185Q452 185 460 172" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch1" />
-      <path d="M445 185Q452 185 460 185" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch2" />
-      <path d="M445 185Q452 185 460 198" stroke={C.primary} strokeWidth="2" strokeLinecap="round" fill="none" className="fl-branch3" />
-      <circle cx="464" cy="172" r="4" fill={C.light} className="fl-dot1" />
-      <circle cx="464" cy="185" r="4" fill={C.primary} className="fl-dot2" />
-      <circle cx="464" cy="198" r="4" fill={C.light} className="fl-dot3" />
+      <path d="M422 195 Q440 175 460 185" fill="none" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl1" />
+      <path d="M432 185 Q450 165 470 175" fill="none" stroke="#6B9AEA" strokeWidth="2" strokeLinecap="round" className="fl-line fl2" />
+      <path d="M442 195 Q460 178 480 185" fill="none" stroke="#6B9AEA" strokeWidth="1.5" strokeLinecap="round" className="fl-line fl3" />
+      <circle cx="422" cy="195" r="3.5" fill="#6B9AEA" className="fl-dot fl-dot1" />
+      <circle cx="450" cy="173" r="3" fill="#6B9AEA" className="fl-dot fl-dot2" />
+      <circle cx="480" cy="185" r="3.5" fill="#6B9AEA" className="fl-dot fl-dot3" />
     </svg>
   )
 }
 
-function HexAvatar({ size = 80, variant = 1 }) {
+function HexAvatar({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      <circle cx="455" cy="175" r="12" stroke={C.light} strokeWidth="2" fill={C.primary} opacity="0.06" className="av-ring2" />
-      <circle cx="452" cy="173" r="2" fill={C.primary} />
-      <circle cx="458" cy="173" r="2" fill={C.primary} />
-      <path d="M451 178Q455 182 459 178" stroke={C.primary} strokeWidth="1.5" strokeLinecap="round" fill="none" />
-      <path d="M442 195Q455 188 468 195" stroke={C.light} strokeWidth="2.5" strokeLinecap="round" fill="none" />
+      <circle cx="455" cy="175" r="12" stroke="#6B9AEA" strokeWidth="2" fill="#3B7BF2" opacity="0.06" className="av-ring av-ring2" />
+      <circle cx="452" cy="173" r="2" fill="#3B7BF2" />
+      <circle cx="458" cy="173" r="2" fill="#3B7BF2" />
+      <path d="M451 178Q455 182 459 178" stroke="#3B7BF2" strokeWidth="1.5" strokeLinecap="round" fill="none" />
+      <path d="M442 195Q455 188 468 195" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" />
     </svg>
   )
 }
 
-/* ═══ DISPLAY COMPONENTS ═══ */
+/* ── DISPLAY ── */
 function IconRow({ label, description, variants, hexComponent: HexComp, sizes = [16, 24, 32, 40, 64] }) {
   return (
     <div className="mb-16">
-      <h3 className="text-xl font-bold text-text mb-1 tracking-tight" style={{ fontFamily: 'var(--font-outfit)' }}>
-        {label}
-      </h3>
+      <h3 className="text-xl font-bold text-text mb-1 tracking-tight" style={{ fontFamily: 'var(--font-outfit)' }}>{label}</h3>
       {description && <p className="text-sm text-text-secondary mb-6">{description}</p>}
-
-      {/* Hex version */}
       {HexComp && (
         <div className="mb-8">
           <p className="text-[10px] font-semibold text-text-secondary uppercase tracking-wider mb-3">Hex Logo Version</p>
           <div className="flex items-end gap-6">
-            <div className="flex flex-col items-center gap-2">
-              <div className="flex items-center justify-center rounded-xl p-3" style={{ background: 'rgba(0,0,0,0.02)', border: '1px solid rgba(0,0,0,0.04)' }}>
-                <HexComp size={100} />
+            {[100, 48].map(s => (
+              <div key={s} className="flex flex-col items-center gap-2">
+                <div className="flex items-center justify-center rounded-xl p-3" style={{ background: 'rgba(0,0,0,0.02)', border: '1px solid rgba(0,0,0,0.04)' }}>
+                  <HexComp size={s} />
+                </div>
+                <span className="text-[10px] text-text-secondary font-mono">{s}px</span>
               </div>
-              <span className="text-[10px] text-text-secondary font-mono">100px hex</span>
-            </div>
-            <div className="flex flex-col items-center gap-2">
-              <div className="flex items-center justify-center rounded-xl p-2" style={{ background: 'rgba(0,0,0,0.02)', border: '1px solid rgba(0,0,0,0.04)' }}>
-                <HexComp size={48} />
-              </div>
-              <span className="text-[10px] text-text-secondary font-mono">48px hex</span>
-            </div>
+            ))}
           </div>
         </div>
       )}
-
-      {/* Accent-only variants */}
       <div className="space-y-8">
         {variants.map(({ name, Component, picked }, vi) => (
           <div key={vi} className={picked ? 'rounded-2xl p-5 -mx-5' : ''} style={picked ? { background: 'rgba(59,123,242,0.04)', border: '1px solid rgba(59,123,242,0.1)' } : {}}>
@@ -276,7 +297,7 @@ function IconRow({ label, description, variants, hexComponent: HexComp, sizes = 
               {picked && <span className="text-[10px] font-bold text-primary bg-primary/10 px-2 py-0.5 rounded-full">PICKED</span>}
             </div>
             <div className="flex items-end gap-6 flex-wrap">
-              {sizes.map((s) => (
+              {sizes.map(s => (
                 <div key={s} className="flex flex-col items-center gap-2">
                   <div className="flex items-center justify-center rounded-xl"
                     style={{ width: Math.max(s + 16, 40), height: Math.max(s + 16, 40), background: 'rgba(0,0,0,0.02)', border: '1px solid rgba(0,0,0,0.04)' }}>
@@ -293,162 +314,230 @@ function IconRow({ label, description, variants, hexComponent: HexComp, sizes = 
   )
 }
 
-/* ═══ PAGE ═══ */
+/* ── PAGE ── */
 export default function IconExplorationPage() {
   return (
     <div className="min-h-screen bg-bg pt-28 pb-20">
-      {/* All animations using brand blue only */}
       <style jsx global>{`
-        /* Receptionist: waveform bars - heartbeat style from original */
-        .rc-bar1 { animation: rcPulse 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center bottom; }
-        .rc-bar2 { animation: rcPulse 10s ease-in-out infinite 0.1s; transform-box: fill-box; transform-origin: center bottom; }
-        .rc-bar3 { animation: rcPulse 10s ease-in-out infinite 0.2s; transform-box: fill-box; transform-origin: center bottom; }
-        .rc-bar4 { animation: rcPulse 10s ease-in-out infinite 0.3s; transform-box: fill-box; transform-origin: center bottom; }
-        .rc-bar5 { animation: rcPulse 10s ease-in-out infinite 0.4s; transform-box: fill-box; transform-origin: center bottom; }
-        .rc-bar6 { animation: rcPulse 10s ease-in-out infinite 0.5s; transform-box: fill-box; transform-origin: center bottom; }
-        @keyframes rcPulse {
-          0%   { opacity: 0.45; transform: scaleY(0.7); }
-          3%   { opacity: 1;    transform: scaleY(1.15); }
-          5%   { opacity: 0.6;  transform: scaleY(0.85); }
-          7%   { opacity: 1;    transform: scaleY(1.05); }
-          10%  { opacity: 0.45; transform: scaleY(0.7); }
-          100% { opacity: 0.45; transform: scaleY(0.7); }
+        /* ═══ Waveform bars (Receptionist) ═══
+           10s heartbeat: color shifts #6B9AEA -> #2D6AE0 */
+        .vb1 { animation: vbPulse 10s ease-in-out infinite 0s; }
+        .vb2 { animation: vbPulse 10s ease-in-out infinite 0.1s; }
+        .vb3 { animation: vbPulse 10s ease-in-out infinite 0.2s; }
+        .vb4 { animation: vbPulse 10s ease-in-out infinite 0.3s; }
+        .vb5 { animation: vbPulse 10s ease-in-out infinite 0.4s; }
+        .vb6 { animation: vbPulse 10s ease-in-out infinite 0.5s; }
+        @keyframes vbPulse {
+          0%   { opacity: 0.55; fill: #6B9AEA; }
+          3%   { opacity: 1;    fill: #2D6AE0; }
+          5%   { opacity: 0.65; fill: #6B9AEA; }
+          7%   { opacity: 1;    fill: #2D6AE0; }
+          10%  { opacity: 0.55; fill: #6B9AEA; }
+          100% { opacity: 0.55; fill: #6B9AEA; }
         }
 
-        /* Messenger: typing dots - scale pulse from original */
-        .msg-dot1 { animation: msgDot 1.4s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
-        .msg-dot2 { animation: msgDot 1.4s ease-in-out infinite 0.2s; transform-box: fill-box; transform-origin: center; }
-        .msg-dot3 { animation: msgDot 1.4s ease-in-out infinite 0.4s; transform-box: fill-box; transform-origin: center; }
-        @keyframes msgDot {
-          0%, 60%, 100% { transform: scale(1); opacity: 0.35; }
-          30% { transform: scale(1.4); opacity: 1; }
+        /* ═══ Messenger dots (scale pulse) ═══
+           Heartbeat: scale 1 -> 1.3 -> 1 -> 1.2 -> 1 */
+        .md1 { animation: mdDot 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
+        .md2 { animation: mdDot 10s ease-in-out infinite 0.15s; transform-box: fill-box; transform-origin: center; }
+        .md3 { animation: mdDot 10s ease-in-out infinite 0.3s; transform-box: fill-box; transform-origin: center; }
+        @keyframes mdDot {
+          0%   { transform: scale(1); opacity: 0.45; }
+          3%   { transform: scale(1.3); opacity: 1; }
+          5%   { transform: scale(1); opacity: 0.55; }
+          7%   { transform: scale(1.2); opacity: 1; }
+          10%  { transform: scale(1); opacity: 0.45; }
+          100% { transform: scale(1); opacity: 0.45; }
         }
 
-        /* Outreach: paper plane gentle float */
-        .outreach-plane {
-          animation: planeDrift 3s ease-in-out infinite;
-          transform-box: fill-box;
-          transform-origin: center;
-        }
-        @keyframes planeDrift {
-          0%, 100% { transform: translate(0, 0); }
-          50% { transform: translate(3px, -2px); }
-        }
-
-        /* Space: shapes carousel - each pulses in sequence */
-        .sp-shape1 { animation: spCarousel 16s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
-        .sp-shape2 { animation: spCarousel 16s ease-in-out infinite 4s; transform-box: fill-box; transform-origin: center; }
-        .sp-shape3 { animation: spCarousel 16s ease-in-out infinite 8s; transform-box: fill-box; transform-origin: center; }
-        .sp-shape4 { animation: spCarousel 16s ease-in-out infinite 12s; transform-box: fill-box; transform-origin: center; }
-        @keyframes spCarousel {
-          0%   { opacity: 0.3; transform: scale(0.85); }
-          6%   { opacity: 1;   transform: scale(1.1); }
-          20%  { opacity: 1;   transform: scale(1); }
-          25%  { opacity: 0.3; transform: scale(0.85); }
-          100% { opacity: 0.3; transform: scale(0.85); }
+        /* ═══ Paper planes (Outreach) ═══
+           Fly from lower-left outward upper-right, staggered */
+        .pp1 { animation: ppFly 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
+        .pp2 { animation: ppFly 10s ease-in-out infinite 0.8s; transform-box: fill-box; transform-origin: center; }
+        .pp3 { animation: ppFly 10s ease-in-out infinite 1.6s; transform-box: fill-box; transform-origin: center; }
+        @keyframes ppFly {
+          0%   { opacity: 0; transform: translate(-8px, 6px) scale(0.6); }
+          2%   { opacity: 1; transform: translate(0, 0) scale(1); }
+          5%   { opacity: 1; transform: translate(5px, -4px) scale(1.05); }
+          8%   { opacity: 0; transform: translate(12px, -8px) scale(0.7); }
+          10%  { opacity: 0; transform: translate(-8px, 6px) scale(0.6); }
+          100% { opacity: 0; transform: translate(-8px, 6px) scale(0.6); }
         }
 
-        /* Flow: branching lines + dots pulse */
-        .fl-dot-in { animation: flDotPulse 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
-        .fl-dot1 { animation: flDotPulse 10s ease-in-out infinite 0.2s; transform-box: fill-box; transform-origin: center; }
-        .fl-dot2 { animation: flDotPulse 10s ease-in-out infinite 0.4s; transform-box: fill-box; transform-origin: center; }
-        .fl-dot3 { animation: flDotPulse 10s ease-in-out infinite 0.6s; transform-box: fill-box; transform-origin: center; }
-        .fl-line, .fl-branch1, .fl-branch2, .fl-branch3 { animation: flLinePulse 10s ease-in-out infinite; }
-        @keyframes flDotPulse {
-          0%   { opacity: 0.35; transform: scale(1); }
-          3%   { opacity: 1;    transform: scale(1.3); }
-          5%   { opacity: 0.5;  transform: scale(1); }
-          7%   { opacity: 1;    transform: scale(1.2); }
-          10%  { opacity: 0.35; transform: scale(1); }
-          100% { opacity: 0.35; transform: scale(1); }
+        /* ═══ Shape carousel (Space) ═══
+           16s cycle, 4 shapes, one visible at a time */
+        .cs-circle   { animation: csSlot1 16s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+        .cs-diamond  { animation: csSlot2 16s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+        .cs-triangle { animation: csSlot3 16s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+        .cs-square   { animation: csSlot4 16s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+        @keyframes csSlot1 {
+          0%   { opacity: 0; transform: translate(-10px, 6px) scale(0.8); }
+          3%   { opacity: 1; transform: translate(0, 0) scale(1); }
+          20%  { opacity: 1; transform: translate(0, 0) scale(1); }
+          25%  { opacity: 0; transform: translate(10px, -6px) scale(0.8); }
+          100% { opacity: 0; }
         }
+        @keyframes csSlot2 {
+          0%   { opacity: 0; }
+          25%  { opacity: 0; transform: translate(-10px, 6px) scale(0.8); }
+          28%  { opacity: 1; transform: translate(0, 0) scale(1); }
+          45%  { opacity: 1; transform: translate(0, 0) scale(1); }
+          50%  { opacity: 0; transform: translate(10px, -6px) scale(0.8); }
+          100% { opacity: 0; }
+        }
+        @keyframes csSlot3 {
+          0%   { opacity: 0; }
+          50%  { opacity: 0; transform: translate(-10px, 6px) scale(0.8); }
+          53%  { opacity: 1; transform: translate(0, 0) scale(1); }
+          70%  { opacity: 1; transform: translate(0, 0) scale(1); }
+          75%  { opacity: 0; transform: translate(10px, -6px) scale(0.8); }
+          100% { opacity: 0; }
+        }
+        @keyframes csSlot4 {
+          0%   { opacity: 0; }
+          75%  { opacity: 0; transform: translate(-10px, 6px) scale(0.8); }
+          78%  { opacity: 1; transform: translate(0, 0) scale(1); }
+          95%  { opacity: 1; transform: translate(0, 0) scale(1); }
+          100% { opacity: 0; transform: translate(10px, -6px) scale(0.8); }
+        }
+
+        /* ═══ Flow lines + dots (data flowing) ═══
+           Lines pulse color, dots pulse + data packet travels */
+        .fl-line { animation: flLinePulse 10s ease-in-out infinite; }
+        .fl1 { animation-delay: 0s; }
+        .fl2 { animation-delay: 0.15s; }
+        .fl3 { animation-delay: 0.3s; }
         @keyframes flLinePulse {
-          0%   { opacity: 0.3; stroke: ${C.light}; }
-          3%   { opacity: 1;   stroke: ${C.dark}; }
-          5%   { opacity: 0.4; stroke: ${C.light}; }
-          7%   { opacity: 0.9; stroke: ${C.dark}; }
-          10%  { opacity: 0.3; stroke: ${C.light}; }
-          100% { opacity: 0.3; stroke: ${C.light}; }
+          0%   { opacity: 0.25; stroke: #6B9AEA; }
+          3%   { opacity: 1;    stroke: #2D6AE0; }
+          5%   { opacity: 0.35; stroke: #6B9AEA; }
+          7%   { opacity: 0.9;  stroke: #2D6AE0; }
+          10%  { opacity: 0.25; stroke: #6B9AEA; }
+          100% { opacity: 0.25; stroke: #6B9AEA; }
+        }
+        .fl-dot { animation: flDotPulse 10s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+        .fl-dot1 { animation-delay: 0s; }
+        .fl-dot2 { animation-delay: 0.15s; }
+        .fl-dot3 { animation-delay: 0.3s; }
+        @keyframes flDotPulse {
+          0%   { opacity: 0.4; fill: #6B9AEA; }
+          3%   { opacity: 1;   fill: #2D6AE0; }
+          5%   { opacity: 0.5; fill: #6B9AEA; }
+          7%   { opacity: 1;   fill: #2D6AE0; }
+          10%  { opacity: 0.4; fill: #6B9AEA; }
+          100% { opacity: 0.4; fill: #6B9AEA; }
+        }
+        /* Source dot: constant pulse */
+        .fl-src { animation: flSrcPulse 10s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+        @keyframes flSrcPulse {
+          0%   { transform: scale(1); opacity: 0.6; }
+          3%   { transform: scale(1.2); opacity: 1; }
+          7%   { transform: scale(1); opacity: 0.6; }
+          100% { transform: scale(1); opacity: 0.6; }
+        }
+        .fl-junc { animation: flDotPulse 10s ease-in-out infinite 0.1s; transform-box: fill-box; transform-origin: center; }
+        .fl-out { animation: flOutPulse 10s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
+        .fl-out1 { animation-delay: 0.3s; }
+        .fl-out2 { animation-delay: 0.45s; }
+        .fl-out3 { animation-delay: 0.6s; }
+        @keyframes flOutPulse {
+          0%   { transform: scale(0.7); opacity: 0.2; fill: #6B9AEA; }
+          4%   { transform: scale(1.2); opacity: 1; fill: #2D6AE0; }
+          7%   { transform: scale(1); opacity: 0.8; fill: #3B7BF2; }
+          10%  { transform: scale(0.7); opacity: 0.2; fill: #6B9AEA; }
+          100% { transform: scale(0.7); opacity: 0.2; fill: #6B9AEA; }
+        }
+        /* Data packet travels from source through junction to outputs */
+        .fl-packet { animation: flPacket 10s ease-in-out infinite; }
+        @keyframes flPacket {
+          0%   { cx: 8;  cy: 28; opacity: 0; r: 2; }
+          1%   { cx: 8;  cy: 28; opacity: 1; r: 2.5; }
+          3%   { cx: 18; cy: 20; opacity: 1; r: 2; }
+          4%   { cx: 18; cy: 20; opacity: 0.8; r: 1.5; }
+          6%   { cx: 32; cy: 20; opacity: 0.6; r: 1; }
+          8%   { opacity: 0; }
+          100% { opacity: 0; }
         }
 
-        /* Avatar: rings pulse */
-        .av-ring1 { animation: avRing 3s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
-        .av-ring2 { animation: avRing 3s ease-in-out 0.5s infinite; transform-box: fill-box; transform-origin: center; }
-        @keyframes avRing {
-          0%, 100% { opacity: 0.15; transform: scale(0.97); }
-          50% { opacity: 0.4; transform: scale(1.03); }
+        /* ═══ Heartbeat dots (Parent brand / Messenger hex / Avatar V3) ═══ */
+        .hb1 { animation: hbDot 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
+        .hb2 { animation: hbDot 10s ease-in-out infinite 0.15s; transform-box: fill-box; transform-origin: center; }
+        .hb3 { animation: hbDot 10s ease-in-out infinite 0.3s; transform-box: fill-box; transform-origin: center; }
+        @keyframes hbDot {
+          0%   { transform: scale(1); opacity: 0.55; }
+          3%   { transform: scale(1.3); opacity: 1; }
+          5%   { transform: scale(1); opacity: 0.7; }
+          7%   { transform: scale(1.2); opacity: 1; }
+          10%  { transform: scale(1); opacity: 0.55; }
+          100% { transform: scale(1); opacity: 0.55; }
         }
-        .av-merge1 { animation: avMerge 4s ease-in-out infinite; transform-box: fill-box; transform-origin: center; }
-        .av-merge2 { animation: avMerge 4s ease-in-out 2s infinite; transform-box: fill-box; transform-origin: center; }
-        @keyframes avMerge {
-          0%, 100% { opacity: 0.04; transform: scale(1); }
-          50% { opacity: 0.12; transform: scale(1.05); }
+
+        /* ═══ Avatar rings ═══ */
+        .av-ring1 { animation: avRingPulse 10s ease-in-out infinite 0s; transform-box: fill-box; transform-origin: center; }
+        .av-ring2 { animation: avRingPulse 10s ease-in-out infinite 0.2s; transform-box: fill-box; transform-origin: center; }
+        @keyframes avRingPulse {
+          0%   { transform: scale(0.95); opacity: 0.15; }
+          3%   { transform: scale(1.05); opacity: 0.5; }
+          5%   { transform: scale(0.98); opacity: 0.25; }
+          7%   { transform: scale(1.03); opacity: 0.4; }
+          10%  { transform: scale(0.95); opacity: 0.15; }
+          100% { transform: scale(0.95); opacity: 0.15; }
+        }
+        .av-live { animation: avLive 2s ease-in-out infinite; }
+        @keyframes avLive {
+          0%, 100% { opacity: 0.5; }
+          50% { opacity: 1; }
         }
       `}</style>
 
       <div className="max-w-6xl mx-auto px-6">
         <AnimatedSection>
-          <Badge variant="blue" className="mb-4">Design Exploration v2</Badge>
+          <Badge variant="blue" className="mb-4">Design Exploration v3</Badge>
           <h1 className="text-4xl font-extrabold text-text tracking-tight mb-3" style={{ fontFamily: 'var(--font-outfit)' }}>
-            Product Icon Family (Animated + Hex)
+            Product Icon Family
           </h1>
           <p className="text-text-secondary max-w-2xl mb-2">
-            All icons use unified brand blue (#3B7BF2 / #6B9AEA / #2D6AE0).
-            Animations match the original hex accent patterns (10s cycle, brief burst then rest).
-            Each product shows: hex logo version + accent-only variants at multiple sizes.
+            All icons use brand blue (#3B7BF2 / #6B9AEA / #2D6AE0). All animations use 10s heartbeat cycle (brief burst, long rest) matching the original hex accent patterns. Each product shows hex logo + accent-only variants.
           </p>
         </AnimatedSection>
 
         <div className="gradient-divider my-10" />
 
-        <IconRow label="Receptionist" description="Voice waveform bars. Undecided. All three use the same heartbeat animation pattern." hexComponent={HexReceptionist}
+        <IconRow label="Receptionist" description="Voice waveform. Undecided. All use the same vbPulse animation from the original hex." hexComponent={HexReceptionist}
           variants={[
-            { name: 'Symmetric 5-bar', Component: ReceptionistV1 },
+            { name: 'Symmetric 5-bar' , Component: ReceptionistV1 },
             { name: 'Thin 5-bar', Component: ReceptionistV2 },
             { name: 'Asymmetric 6-bar', Component: ReceptionistV3 },
           ]}
         />
-
         <div className="gradient-divider my-10" />
 
-        <IconRow label="Messenger" description="Typing indicator dots. V2 picked." hexComponent={HexMessenger}
-          variants={[
-            { name: 'Three inline dots (scale pulse)', Component: MessengerV2, picked: true },
-          ]}
+        <IconRow label="Messenger" description="Typing dots. V2 picked. Uses heartbeat scale pulse." hexComponent={HexMessenger}
+          variants={[{ name: 'Three dots (heartbeat pulse)', Component: MessengerV2, picked: true }]}
         />
-
         <div className="gradient-divider my-10" />
 
-        <IconRow label="Outreach" description="Paper plane. V1 picked." hexComponent={HexOutreach}
-          variants={[
-            { name: 'Single paper plane (gentle drift)', Component: OutreachV1, picked: true },
-          ]}
+        <IconRow label="Outreach" description="Paper planes fly outward. Uses the original ppFly trajectory (translate + scale + fade, staggered 0.8s)." hexComponent={HexOutreach}
+          variants={[{ name: 'Paper planes (flight trajectory)', Component: OutreachV1, picked: true }]}
         />
-
         <div className="gradient-divider my-10" />
 
-        <IconRow label="Space" description="Multi-tool shapes carousel. V1 picked." hexComponent={HexSpace}
-          variants={[
-            { name: 'Mixed shapes (circle, square, triangle, diamond)', Component: SpaceV1, picked: true },
-          ]}
+        <IconRow label="Space" description="Shape carousel. One shape visible at a time, 16s cycle. Slide in, hold, slide out." hexComponent={HexSpace}
+          variants={[{ name: 'Shape carousel (circle > diamond > triangle > square)', Component: SpaceV1, picked: true }]}
         />
-
         <div className="gradient-divider my-10" />
 
-        <IconRow label="Flow" description="Branching data flow. V3 picked." hexComponent={HexFlow}
-          variants={[
-            { name: 'Branching flow (1 to 3) with pulsing dots', Component: FlowV3, picked: true },
-          ]}
+        <IconRow label="Flow" description="Branching flow. Diagonal alignment. Source dot sends data through junction to 3 output dots. Outputs 'light up' sequentially as data arrives." hexComponent={HexFlow}
+          variants={[{ name: 'Diagonal branch, data packet flows from source to outputs', Component: FlowV3, picked: true }]}
         />
-
         <div className="gradient-divider my-10" />
 
-        <IconRow label="Avatar" description="Human-like AI presence. 4 variations. None picked yet." hexComponent={HexAvatar}
+        <IconRow label="Avatar" description="Human-like AI presence. 4 options. None picked yet." hexComponent={HexAvatar}
           variants={[
-            { name: 'Pulsing rings + face (video call)' , Component: AvatarV1 },
-            { name: 'Face + speaking waveform bars', Component: AvatarV2 },
-            { name: 'Glowing orb with face', Component: AvatarV3 },
-            { name: 'Two merging circles (human meets AI)', Component: AvatarV4 },
+            { name: 'Pulsing rings + face (video call incoming)', Component: AvatarV1 },
+            { name: 'Face + speaking waveform (AI that talks)', Component: AvatarV2 },
+            { name: 'Ascending circles with face (brand-style)', Component: AvatarV3 },
+            { name: 'Video frame + face + live dot', Component: AvatarV4 },
           ]}
         />
       </div>

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -1,110 +1,142 @@
+'use client'
+
 import { AnimatedSection } from '@/components/ui/AnimatedSection'
 import { Badge } from '@/components/ui/Badge'
 
-export const metadata = {
-  title: 'Icon Design Exploration',
-  robots: { index: false },
-}
-
 /* ─────────────────────────────────────────────────
-   ACCENT-FORWARD ICONS (no hex container)
-   Each product's accent element as a standalone icon.
-   Multiple variations per product to explore.
+   ACCENT-FORWARD ANIMATED ICONS
+   Each icon has its own CSS keyframe animation
+   matching the original hex accent behavior.
 ───────────────────────────────────────────────────── */
 
 // ── RECEPTIONIST: Waveform bars ──
 function ReceptionistV1({ size = 40, color = '#3B7BF2' }) {
+  const barAnim = (delay) => ({
+    animation: `waveBar 1.2s ease-in-out ${delay}s infinite alternate`,
+    transformBox: 'fill-box',
+    transformOrigin: 'center bottom',
+  })
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <rect x="4" y="16" width="5" height="8" rx="2.5" fill={color} opacity="0.5" />
-      <rect x="11" y="10" width="5" height="20" rx="2.5" fill={color} opacity="0.65" />
-      <rect x="18" y="6" width="5" height="28" rx="2.5" fill={color} />
-      <rect x="25" y="12" width="5" height="16" rx="2.5" fill={color} opacity="0.65" />
-      <rect x="32" y="14" width="5" height="12" rx="2.5" fill={color} opacity="0.5" />
+      <rect x="4" y="16" width="5" height="8" rx="2.5" fill={color} opacity="0.5" style={barAnim(0)} />
+      <rect x="11" y="10" width="5" height="20" rx="2.5" fill={color} opacity="0.65" style={barAnim(0.1)} />
+      <rect x="18" y="6" width="5" height="28" rx="2.5" fill={color} style={barAnim(0.2)} />
+      <rect x="25" y="12" width="5" height="16" rx="2.5" fill={color} opacity="0.65" style={barAnim(0.3)} />
+      <rect x="32" y="14" width="5" height="12" rx="2.5" fill={color} opacity="0.5" style={barAnim(0.4)} />
     </svg>
   )
 }
 
 function ReceptionistV2({ size = 40, color = '#3B7BF2' }) {
+  const barAnim = (delay) => ({
+    animation: `waveBar 1.4s ease-in-out ${delay}s infinite alternate`,
+    transformBox: 'fill-box',
+    transformOrigin: 'center bottom',
+  })
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <rect x="6" y="18" width="4" height="4" rx="2" fill={color} opacity="0.4" />
-      <rect x="13" y="12" width="4" height="16" rx="2" fill={color} opacity="0.6" />
-      <rect x="20" y="6" width="4" height="28" rx="2" fill={color} />
-      <rect x="27" y="10" width="4" height="20" rx="2" fill={color} opacity="0.6" />
-      <rect x="34" y="16" width="4" height="8" rx="2" fill={color} opacity="0.4" />
+      <rect x="6" y="18" width="4" height="4" rx="2" fill={color} opacity="0.4" style={barAnim(0)} />
+      <rect x="13" y="12" width="4" height="16" rx="2" fill={color} opacity="0.6" style={barAnim(0.12)} />
+      <rect x="20" y="6" width="4" height="28" rx="2" fill={color} style={barAnim(0.24)} />
+      <rect x="27" y="10" width="4" height="20" rx="2" fill={color} opacity="0.6" style={barAnim(0.36)} />
+      <rect x="34" y="16" width="4" height="8" rx="2" fill={color} opacity="0.4" style={barAnim(0.48)} />
     </svg>
   )
 }
 
 function ReceptionistV3({ size = 40, color = '#3B7BF2' }) {
+  const barAnim = (delay) => ({
+    animation: `waveBar 1.0s ease-in-out ${delay}s infinite alternate`,
+    transformBox: 'fill-box',
+    transformOrigin: 'center bottom',
+  })
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <rect x="5" y="17" width="3.5" height="6" rx="1.75" fill={color} opacity="0.45" />
-      <rect x="11" y="12" width="3.5" height="16" rx="1.75" fill={color} opacity="0.6" />
-      <rect x="17" y="7" width="4" height="26" rx="2" fill={color} />
-      <rect x="23.5" y="9" width="3.5" height="22" rx="1.75" fill={color} opacity="0.75" />
-      <rect x="29.5" y="13" width="3.5" height="14" rx="1.75" fill={color} opacity="0.55" />
-      <rect x="35.5" y="17" width="3.5" height="6" rx="1.75" fill={color} opacity="0.35" />
+      <rect x="5" y="17" width="3.5" height="6" rx="1.75" fill={color} opacity="0.45" style={barAnim(0)} />
+      <rect x="11" y="12" width="3.5" height="16" rx="1.75" fill={color} opacity="0.6" style={barAnim(0.08)} />
+      <rect x="17" y="7" width="4" height="26" rx="2" fill={color} style={barAnim(0.16)} />
+      <rect x="23.5" y="9" width="3.5" height="22" rx="1.75" fill={color} opacity="0.75" style={barAnim(0.24)} />
+      <rect x="29.5" y="13" width="3.5" height="14" rx="1.75" fill={color} opacity="0.55" style={barAnim(0.32)} />
+      <rect x="35.5" y="17" width="3.5" height="6" rx="1.75" fill={color} opacity="0.35" style={barAnim(0.4)} />
     </svg>
   )
 }
 
-// ── MESSENGER: Typing/chat dots ──
+// ── MESSENGER: Typing dots ── (V2 is the pick)
 function MessengerV1({ size = 40, color = '#6366F1' }) {
+  const dotAnim = (delay) => ({
+    animation: `typingDot 1.4s ease-in-out ${delay}s infinite`,
+    transformBox: 'fill-box',
+    transformOrigin: 'center',
+  })
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="10" cy="24" r="4" stroke={color} strokeWidth="2" fill="none" opacity="0.5" />
-      <circle cx="20" cy="18" r="5.5" stroke={color} strokeWidth="2" fill="none" opacity="0.7" />
-      <circle cx="31" cy="14" r="7" stroke={color} strokeWidth="2" fill="none" />
+      <circle cx="10" cy="24" r="4" stroke={color} strokeWidth="2" fill="none" opacity="0.5" style={dotAnim(0)} />
+      <circle cx="20" cy="18" r="5.5" stroke={color} strokeWidth="2" fill="none" opacity="0.7" style={dotAnim(0.15)} />
+      <circle cx="31" cy="14" r="7" stroke={color} strokeWidth="2" fill="none" style={dotAnim(0.3)} />
     </svg>
   )
 }
 
 function MessengerV2({ size = 40, color = '#6366F1' }) {
+  const dotAnim = (delay) => ({
+    animation: `typingDot 1.4s ease-in-out ${delay}s infinite`,
+    transformBox: 'fill-box',
+    transformOrigin: 'center',
+  })
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="10" cy="20" r="3" fill={color} opacity="0.35" />
-      <circle cx="20" cy="20" r="3" fill={color} opacity="0.6" />
-      <circle cx="30" cy="20" r="3" fill={color} />
+      <circle cx="10" cy="20" r="3" fill={color} opacity="0.35" style={dotAnim(0)} />
+      <circle cx="20" cy="20" r="3" fill={color} opacity="0.6" style={dotAnim(0.2)} />
+      <circle cx="30" cy="20" r="3" fill={color} style={dotAnim(0.4)} />
     </svg>
   )
 }
 
 function MessengerV3({ size = 40, color = '#6366F1' }) {
+  const dotAnim = (delay) => ({
+    animation: `typingDot 1.4s ease-in-out ${delay}s infinite`,
+    transformBox: 'fill-box',
+    transformOrigin: 'center',
+  })
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* Chat bubble shape with dots inside */}
       <path d="M6 10h28a2 2 0 012 2v14a2 2 0 01-2 2H14l-6 5v-5H6a2 2 0 01-2-2V12a2 2 0 012-2z" stroke={color} strokeWidth="1.8" fill="none" opacity="0.25" />
-      <circle cx="13" cy="19" r="2.5" fill={color} opacity="0.4" />
-      <circle cx="20" cy="19" r="2.5" fill={color} opacity="0.65" />
-      <circle cx="27" cy="19" r="2.5" fill={color} />
+      <circle cx="13" cy="19" r="2.5" fill={color} opacity="0.4" style={dotAnim(0)} />
+      <circle cx="20" cy="19" r="2.5" fill={color} opacity="0.65" style={dotAnim(0.2)} />
+      <circle cx="27" cy="19" r="2.5" fill={color} style={dotAnim(0.4)} />
     </svg>
   )
 }
 
-// ── OUTREACH: Paper planes ──
+// ── OUTREACH: Paper planes ── (V1 is the pick)
 function OutreachV1({ size = 40, color = '#0EA5E9' }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <path d="M6 20l28-14-8 16-6-4-14 2z" fill={color} opacity="0.15" />
-      <path d="M6 20l28-14-8 16-6-4-14 2z" stroke={color} strokeWidth="1.8" strokeLinejoin="round" fill="none" />
-      <path d="M20 18l6 14" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+      <g style={{ animation: 'planeFly 3s ease-in-out infinite' }}>
+        <path d="M6 20l28-14-8 16-6-4-14 2z" fill={color} opacity="0.12" />
+        <path d="M6 20l28-14-8 16-6-4-14 2z" stroke={color} strokeWidth="1.8" strokeLinejoin="round" fill="none" />
+        <path d="M20 18l6 14" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+      </g>
     </svg>
   )
 }
 
 function OutreachV2({ size = 40, color = '#0EA5E9' }) {
+  const planeAnim = (delay) => ({
+    animation: `planeDispatch 2.5s ease-in-out ${delay}s infinite`,
+    transformBox: 'fill-box',
+    transformOrigin: 'center',
+  })
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* Three small planes at different positions like dispatching */}
-      <g opacity="0.35" transform="translate(4, 24) scale(0.6)">
+      <g opacity="0.35" transform="translate(4, 24) scale(0.6)" style={planeAnim(0)}>
         <path d="M0 8l20-8-6 10-4-3L0 8z" fill={color} />
       </g>
-      <g opacity="0.65" transform="translate(12, 14) scale(0.8)">
+      <g opacity="0.65" transform="translate(12, 14) scale(0.8)" style={planeAnim(0.6)}>
         <path d="M0 8l20-8-6 10-4-3L0 8z" fill={color} />
       </g>
-      <g transform="translate(18, 4) scale(1)">
+      <g transform="translate(18, 4) scale(1)" style={planeAnim(1.2)}>
         <path d="M0 8l20-8-6 10-4-3L0 8z" fill={color} />
       </g>
     </svg>
@@ -114,23 +146,24 @@ function OutreachV2({ size = 40, color = '#0EA5E9' }) {
 function OutreachV3({ size = 40, color = '#0EA5E9' }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* Single bold send arrow */}
-      <path d="M6 34L8 20 34 6 20 32 16 22z" fill={color} opacity="0.12" />
-      <path d="M6 34L34 6" stroke={color} strokeWidth="2" strokeLinecap="round" />
-      <path d="M34 6L20 32" stroke={color} strokeWidth="1.8" strokeLinecap="round" />
-      <path d="M20 32L16 22L6 34" stroke={color} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+      <g style={{ animation: 'planeFly 3s ease-in-out infinite' }}>
+        <path d="M6 34L8 20 34 6 20 32 16 22z" fill={color} opacity="0.12" />
+        <path d="M6 34L34 6" stroke={color} strokeWidth="2" strokeLinecap="round" />
+        <path d="M34 6L20 32" stroke={color} strokeWidth="1.8" strokeLinecap="round" />
+        <path d="M20 32L16 22L6 34" stroke={color} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+      </g>
     </svg>
   )
 }
 
-// ── SPACE: Shape grid / multi-tool ──
+// ── SPACE: Shape carousel ── (V1 is the pick)
 function SpaceV1({ size = 40, color = '#3B7BF2' }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="12" cy="12" r="6" fill={color} opacity="0.7" />
-      <rect x="22" y="6" width="12" height="12" rx="2" fill={color} opacity="0.5" />
-      <polygon points="12,28 18,40 6,40" fill={color} opacity="0.4" />
-      <polygon points="28,26 34,32 28,38 22,32" fill={color} opacity="0.6" />
+      <circle cx="12" cy="12" r="6" fill={color} opacity="0.7" style={{ animation: 'shapeRotate 8s ease-in-out infinite 0s' }} />
+      <rect x="22" y="6" width="12" height="12" rx="2" fill={color} opacity="0.5" style={{ animation: 'shapeRotate 8s ease-in-out infinite 2s' }} />
+      <polygon points="12,28 18,40 6,40" fill={color} opacity="0.4" style={{ animation: 'shapeRotate 8s ease-in-out infinite 4s' }} />
+      <polygon points="28,26 34,32 28,38 22,32" fill={color} opacity="0.6" style={{ animation: 'shapeRotate 8s ease-in-out infinite 6s' }} />
     </svg>
   )
 }
@@ -138,11 +171,10 @@ function SpaceV1({ size = 40, color = '#3B7BF2' }) {
 function SpaceV2({ size = 40, color = '#3B7BF2' }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* 2x2 grid of rounded squares */}
-      <rect x="4" y="4" width="14" height="14" rx="4" fill={color} opacity="0.8" />
-      <rect x="22" y="4" width="14" height="14" rx="4" fill={color} opacity="0.5" />
-      <rect x="4" y="22" width="14" height="14" rx="4" fill={color} opacity="0.5" />
-      <rect x="22" y="22" width="14" height="14" rx="4" fill={color} opacity="0.3" />
+      <rect x="4" y="4" width="14" height="14" rx="4" fill={color} opacity="0.8" style={{ animation: 'shapePulse 2s ease-in-out infinite 0s' }} />
+      <rect x="22" y="4" width="14" height="14" rx="4" fill={color} opacity="0.5" style={{ animation: 'shapePulse 2s ease-in-out infinite 0.3s' }} />
+      <rect x="4" y="22" width="14" height="14" rx="4" fill={color} opacity="0.5" style={{ animation: 'shapePulse 2s ease-in-out infinite 0.6s' }} />
+      <rect x="22" y="22" width="14" height="14" rx="4" fill={color} opacity="0.3" style={{ animation: 'shapePulse 2s ease-in-out infinite 0.9s' }} />
     </svg>
   )
 }
@@ -150,130 +182,146 @@ function SpaceV2({ size = 40, color = '#3B7BF2' }) {
 function SpaceV3({ size = 40, color = '#3B7BF2' }) {
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* Mixed shapes in orbit around center */}
-      <circle cx="20" cy="20" r="3" fill={color} />
-      <circle cx="20" cy="6" r="4" fill={color} opacity="0.7" />
-      <rect x="30" y="16" width="8" height="8" rx="2" fill={color} opacity="0.5" />
+      <circle cx="20" cy="20" r="3" fill={color} style={{ animation: 'shapePulse 2s ease-in-out infinite' }} />
+      <circle cx="20" cy="6" r="4" fill={color} opacity="0.7" style={{ animation: 'orbitSpin 6s linear infinite' , transformOrigin: '20px 20px' }} />
+      <rect x="30" y="16" width="8" height="8" rx="2" fill={color} opacity="0.5" style={{ animation: 'orbitSpin 6s linear infinite reverse', transformOrigin: '20px 20px' }} />
       <polygon points="20,34 24,40 16,40" fill={color} opacity="0.4" />
       <polygon points="4,20 8,16 8,24" fill={color} opacity="0.6" />
     </svg>
   )
 }
 
-// ── FLOW: Curved paths with dots ──
+// ── FLOW: Curved paths with dots ── (V3 is the pick)
 function FlowV1({ size = 40, color = '#6366F1' }) {
+  const lineAnim = (delay) => ({
+    animation: `flowPulse 2s ease-in-out ${delay}s infinite`,
+  })
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <path d="M4 30Q14 10 20 20T36 10" stroke={color} strokeWidth="2.5" strokeLinecap="round" fill="none" />
-      <circle cx="4" cy="30" r="3" fill={color} />
-      <circle cx="20" cy="20" r="2.5" fill={color} opacity="0.6" />
-      <circle cx="36" cy="10" r="3" fill={color} />
+      <path d="M4 30Q14 10 20 20T36 10" stroke={color} strokeWidth="2.5" strokeLinecap="round" fill="none" style={lineAnim(0)} />
+      <circle cx="4" cy="30" r="3" fill={color} style={{ animation: 'dotPulse 2s ease-in-out infinite 0s' }} />
+      <circle cx="20" cy="20" r="2.5" fill={color} opacity="0.6" style={{ animation: 'dotPulse 2s ease-in-out infinite 0.3s' }} />
+      <circle cx="36" cy="10" r="3" fill={color} style={{ animation: 'dotPulse 2s ease-in-out infinite 0.6s' }} />
     </svg>
   )
 }
 
 function FlowV2({ size = 40, color = '#6366F1' }) {
+  const lineAnim = (delay) => ({
+    animation: `flowPulse 2s ease-in-out ${delay}s infinite`,
+  })
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* Three parallel flow lines */}
-      <path d="M4 12Q16 6 36 12" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.4" />
-      <path d="M4 20Q16 14 36 20" stroke={color} strokeWidth="2.5" strokeLinecap="round" fill="none" opacity="0.7" />
-      <path d="M4 28Q16 22 36 28" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.4" />
-      <circle cx="36" cy="12" r="2.5" fill={color} opacity="0.4" />
-      <circle cx="36" cy="20" r="3" fill={color} />
-      <circle cx="36" cy="28" r="2.5" fill={color} opacity="0.4" />
+      <path d="M4 12Q16 6 36 12" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.4" style={lineAnim(0)} />
+      <path d="M4 20Q16 14 36 20" stroke={color} strokeWidth="2.5" strokeLinecap="round" fill="none" opacity="0.7" style={lineAnim(0.15)} />
+      <path d="M4 28Q16 22 36 28" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.4" style={lineAnim(0.3)} />
+      <circle cx="36" cy="12" r="2.5" fill={color} opacity="0.4" style={{ animation: 'dotPulse 2s ease-in-out infinite 0s' }} />
+      <circle cx="36" cy="20" r="3" fill={color} style={{ animation: 'dotPulse 2s ease-in-out infinite 0.2s' }} />
+      <circle cx="36" cy="28" r="2.5" fill={color} opacity="0.4" style={{ animation: 'dotPulse 2s ease-in-out infinite 0.4s' }} />
     </svg>
   )
 }
 
 function FlowV3({ size = 40, color = '#6366F1' }) {
+  const dotAnim = (delay) => ({
+    animation: `dotPulse 2s ease-in-out ${delay}s infinite`,
+  })
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* Branching flow: one input splits to three outputs */}
-      <circle cx="6" cy="20" r="4" fill={color} />
-      <path d="M10 20H18" stroke={color} strokeWidth="2" strokeLinecap="round" />
-      <path d="M18 20Q22 20 26 12" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" />
-      <path d="M18 20Q22 20 26 20" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" />
-      <path d="M18 20Q22 20 26 28" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" />
-      <circle cx="30" cy="12" r="3" fill={color} opacity="0.5" />
-      <circle cx="30" cy="20" r="3" fill={color} opacity="0.7" />
-      <circle cx="30" cy="28" r="3" fill={color} opacity="0.5" />
+      <circle cx="6" cy="20" r="4" fill={color} style={dotAnim(0)} />
+      <path d="M10 20H18" stroke={color} strokeWidth="2" strokeLinecap="round" style={{ animation: 'flowPulse 2s ease-in-out infinite' }} />
+      <path d="M18 20Q22 20 26 12" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" style={{ animation: 'flowPulse 2s ease-in-out 0.1s infinite' }} />
+      <path d="M18 20Q22 20 26 20" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" style={{ animation: 'flowPulse 2s ease-in-out 0.2s infinite' }} />
+      <path d="M18 20Q22 20 26 28" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" style={{ animation: 'flowPulse 2s ease-in-out 0.3s infinite' }} />
+      <circle cx="30" cy="12" r="3" fill={color} opacity="0.5" style={dotAnim(0.2)} />
+      <circle cx="30" cy="20" r="3" fill={color} opacity="0.7" style={dotAnim(0.4)} />
+      <circle cx="30" cy="28" r="3" fill={color} opacity="0.5" style={dotAnim(0.6)} />
     </svg>
   )
 }
 
-// ── AVATAR: Face / human presence ──
+// ── AVATAR: New variations ──
 function AvatarV1({ size = 40, color = '#0EA5E9' }) {
+  // Pulsing concentric circles (like a video call ring)
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <circle cx="20" cy="16" r="10" stroke={color} strokeWidth="2" fill="none" />
-      <circle cx="16" cy="14" r="2" fill={color} />
-      <circle cx="24" cy="14" r="2" fill={color} />
-      <path d="M15 20Q20 25 25 20" stroke={color} strokeWidth="1.8" strokeLinecap="round" fill="none" />
-      <path d="M10 32Q20 26 30 32" stroke={color} strokeWidth="2.5" strokeLinecap="round" fill="none" />
+      <circle cx="20" cy="20" r="16" stroke={color} strokeWidth="1.5" fill="none" opacity="0.15" style={{ animation: 'ringPulse 2s ease-out infinite' }} />
+      <circle cx="20" cy="20" r="11" stroke={color} strokeWidth="1.5" fill="none" opacity="0.3" style={{ animation: 'ringPulse 2s ease-out 0.3s infinite' }} />
+      <circle cx="20" cy="18" r="6" fill={color} opacity="0.12" />
+      <circle cx="18" cy="16.5" r="1.2" fill={color} />
+      <circle cx="22" cy="16.5" r="1.2" fill={color} />
+      <path d="M17 20.5Q20 23 23 20.5" stroke={color} strokeWidth="1.2" strokeLinecap="round" fill="none" />
+      <path d="M12 32Q20 27 28 32" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.4" />
     </svg>
   )
 }
 
 function AvatarV2({ size = 40, color = '#0EA5E9' }) {
+  // Waveform + face (speaking avatar)
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* Simplified head + shoulders silhouette */}
-      <circle cx="20" cy="14" r="8" fill={color} opacity="0.15" stroke={color} strokeWidth="1.8" />
-      <circle cx="17" cy="12.5" r="1.5" fill={color} opacity="0.7" />
-      <circle cx="23" cy="12.5" r="1.5" fill={color} opacity="0.7" />
-      <path d="M16.5 17Q20 20.5 23.5 17" stroke={color} strokeWidth="1.5" strokeLinecap="round" fill="none" />
-      <path d="M6 36Q20 28 34 36" fill={color} opacity="0.1" stroke={color} strokeWidth="1.8" strokeLinecap="round" />
+      <circle cx="20" cy="16" r="8" fill={color} opacity="0.08" stroke={color} strokeWidth="1.5" />
+      <circle cx="17.5" cy="14.5" r="1.3" fill={color} />
+      <circle cx="22.5" cy="14.5" r="1.3" fill={color} />
+      <path d="M17 19Q20 22 23 19" stroke={color} strokeWidth="1.3" strokeLinecap="round" fill="none" />
+      {/* Speaking waveform below face */}
+      <rect x="11" y="30" width="2.5" height="5" rx="1.25" fill={color} opacity="0.3" style={{ animation: 'waveBar 1s ease-in-out 0s infinite alternate' }} />
+      <rect x="15.5" y="28" width="2.5" height="9" rx="1.25" fill={color} opacity="0.5" style={{ animation: 'waveBar 1s ease-in-out 0.1s infinite alternate' }} />
+      <rect x="20" y="27" width="2.5" height="11" rx="1.25" fill={color} opacity="0.7" style={{ animation: 'waveBar 1s ease-in-out 0.2s infinite alternate' }} />
+      <rect x="24.5" y="29" width="2.5" height="7" rx="1.25" fill={color} opacity="0.5" style={{ animation: 'waveBar 1s ease-in-out 0.3s infinite alternate' }} />
+      <rect x="29" y="31" width="2.5" height="3" rx="1.25" fill={color} opacity="0.3" style={{ animation: 'waveBar 1s ease-in-out 0.4s infinite alternate' }} />
     </svg>
   )
 }
 
 function AvatarV3({ size = 40, color = '#0EA5E9' }) {
+  // Glowing orb with face emerging
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      {/* Video frame with face inside */}
-      <rect x="3" y="6" width="34" height="24" rx="4" stroke={color} strokeWidth="1.8" fill="none" opacity="0.3" />
-      <circle cx="20" cy="15" r="5" fill={color} opacity="0.2" stroke={color} strokeWidth="1.5" />
-      <circle cx="18" cy="14" r="1" fill={color} />
-      <circle cx="22" cy="14" r="1" fill={color} />
-      <path d="M17.5 17.5Q20 19.5 22.5 17.5" stroke={color} strokeWidth="1.2" strokeLinecap="round" fill="none" />
-      {/* Record dot */}
-      <circle cx="33" cy="10" r="2" fill="#EF4444" />
+      <circle cx="20" cy="20" r="16" fill={color} opacity="0.06" style={{ animation: 'ringPulse 3s ease-out infinite' }} />
+      <circle cx="20" cy="20" r="12" fill={color} opacity="0.08" />
+      <circle cx="20" cy="18" r="7" fill={color} opacity="0.04" stroke={color} strokeWidth="1.2" />
+      <circle cx="17.5" cy="16" r="1.5" fill={color} opacity="0.8" />
+      <circle cx="22.5" cy="16" r="1.5" fill={color} opacity="0.8" />
+      <path d="M17 21Q20 24 23 21" stroke={color} strokeWidth="1.4" strokeLinecap="round" fill="none" />
     </svg>
   )
 }
 
-// ── HEX WITH SUBTLE CONTAINER (Mode 2) ──
-function HexOutline({ size = 80 }) {
+function AvatarV4({ size = 40, color = '#0EA5E9' }) {
+  // Abstract: two overlapping circles (human + AI merging)
   return (
     <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
-      <path
-        d="M20 2L37 11V29L20 38L3 29V11Z"
-        stroke="#3B7BF2"
-        strokeWidth="1"
-        fill="none"
-        opacity="0.15"
-      />
+      <circle cx="15" cy="20" r="10" stroke={color} strokeWidth="1.8" fill={color} opacity="0.06" style={{ animation: 'shapePulse 3s ease-in-out infinite' }} />
+      <circle cx="25" cy="20" r="10" stroke={color} strokeWidth="1.8" fill={color} opacity="0.06" style={{ animation: 'shapePulse 3s ease-in-out 0.5s infinite' }} />
+      {/* Face in the overlap zone */}
+      <circle cx="18.5" cy="18" r="1.2" fill={color} />
+      <circle cx="21.5" cy="18" r="1.2" fill={color} />
+      <path d="M18 22Q20 24.5 22 22" stroke={color} strokeWidth="1.2" strokeLinecap="round" fill="none" />
     </svg>
   )
 }
 
 // ── DISPLAY COMPONENTS ──
-function IconRow({ label, variants, sizes = [16, 24, 32, 40, 64, 80] }) {
+function IconRow({ label, description, variants, sizes = [16, 24, 32, 40, 64, 80] }) {
   return (
-    <div className="mb-12">
+    <div className="mb-14">
       <h3
-        className="text-lg font-bold text-text mb-1 tracking-tight"
+        className="text-xl font-bold text-text mb-1 tracking-tight"
         style={{ fontFamily: 'var(--font-outfit)' }}
       >
         {label}
       </h3>
-      <div className="space-y-6">
-        {variants.map(({ name, Component, color }, vi) => (
-          <div key={vi}>
-            <p className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-3">
-              Variant {vi + 1}: {name}
-            </p>
+      {description && <p className="text-sm text-text-secondary mb-6">{description}</p>}
+      <div className="space-y-8">
+        {variants.map(({ name, Component, color, picked }, vi) => (
+          <div key={vi} className={picked ? 'rounded-2xl p-5 -mx-5' : ''} style={picked ? { background: 'rgba(59,123,242,0.04)', border: '1px solid rgba(59,123,242,0.1)' } : {}}>
+            <div className="flex items-center gap-2 mb-3">
+              <p className="text-xs font-semibold text-text-secondary uppercase tracking-wider">
+                Variant {vi + 1}: {name}
+              </p>
+              {picked && <span className="text-[10px] font-bold text-primary bg-primary/10 px-2 py-0.5 rounded-full">PICKED</span>}
+            </div>
             <div className="flex items-end gap-6 flex-wrap">
               {sizes.map((s) => (
                 <div key={s} className="flex flex-col items-center gap-2">
@@ -303,6 +351,53 @@ function IconRow({ label, variants, sizes = [16, 24, 32, 40, 64, 80] }) {
 export default function IconExplorationPage() {
   return (
     <div className="min-h-screen bg-bg pt-28 pb-20">
+      <style jsx global>{`
+        @keyframes waveBar {
+          0% { transform: scaleY(0.6); opacity: 0.4; }
+          100% { transform: scaleY(1); opacity: 1; }
+        }
+        @keyframes typingDot {
+          0%, 100% { transform: scale(1); opacity: 0.3; }
+          50% { transform: scale(1.4); opacity: 1; }
+        }
+        @keyframes planeFly {
+          0% { transform: translate(0, 0); }
+          50% { transform: translate(3px, -2px); }
+          100% { transform: translate(0, 0); }
+        }
+        @keyframes planeDispatch {
+          0% { transform: translate(0, 0) scale(1); opacity: 0.3; }
+          50% { transform: translate(4px, -3px) scale(1.1); opacity: 1; }
+          100% { transform: translate(0, 0) scale(1); opacity: 0.3; }
+        }
+        @keyframes shapeRotate {
+          0%, 100% { transform: scale(1); opacity: 0.5; }
+          25% { transform: scale(1.15); opacity: 1; }
+          50% { transform: scale(1); opacity: 0.5; }
+        }
+        @keyframes shapePulse {
+          0%, 100% { transform: scale(1); opacity: 0.7; }
+          50% { transform: scale(1.08); opacity: 1; }
+        }
+        @keyframes flowPulse {
+          0%, 100% { opacity: 0.4; }
+          50% { opacity: 1; }
+        }
+        @keyframes dotPulse {
+          0%, 100% { transform: scale(1); opacity: 0.5; }
+          50% { transform: scale(1.25); opacity: 1; }
+        }
+        @keyframes ringPulse {
+          0% { transform: scale(0.95); opacity: 0.3; }
+          50% { transform: scale(1.05); opacity: 0.15; }
+          100% { transform: scale(0.95); opacity: 0.3; }
+        }
+        @keyframes orbitSpin {
+          0% { transform: rotate(0deg); }
+          100% { transform: rotate(360deg); }
+        }
+      `}</style>
+
       <div className="max-w-6xl mx-auto px-6">
 
         <AnimatedSection>
@@ -311,14 +406,14 @@ export default function IconExplorationPage() {
             className="text-4xl font-extrabold text-text tracking-tight mb-3"
             style={{ fontFamily: 'var(--font-outfit)' }}
           >
-            Product Icon Family
+            Product Icon Family (Animated)
           </h1>
-          <p className="text-text-secondary max-w-2xl mb-4">
-            Accent-forward icons derived from each product's hex logo animation.
-            Three variations per product at multiple sizes. Pick your favorites.
+          <p className="text-text-secondary max-w-2xl mb-2">
+            Accent-forward animated icons. Each reflects its product's hex accent theme.
+            Picked variants are highlighted. Avatar has 4 new variations.
           </p>
           <p className="text-xs text-text-secondary">
-            This page is not indexed. For internal design review only.
+            Internal design review only. Not indexed.
           </p>
         </AnimatedSection>
 
@@ -326,10 +421,11 @@ export default function IconExplorationPage() {
 
         <IconRow
           label="Receptionist"
+          description="Voice/audio waveform. Undecided, review all three with animation."
           variants={[
-            { name: 'Symmetric waveform (5 bars)', Component: ReceptionistV1, color: '#3B7BF2' },
-            { name: 'Thin symmetric (5 bars)', Component: ReceptionistV2, color: '#3B7BF2' },
-            { name: 'Asymmetric waveform (6 bars)', Component: ReceptionistV3, color: '#3B7BF2' },
+            { name: 'Symmetric 5-bar waveform', Component: ReceptionistV1, color: '#3B7BF2' },
+            { name: 'Thin symmetric 5-bar', Component: ReceptionistV2, color: '#3B7BF2' },
+            { name: 'Asymmetric 6-bar waveform', Component: ReceptionistV3, color: '#3B7BF2' },
           ]}
         />
 
@@ -337,9 +433,10 @@ export default function IconExplorationPage() {
 
         <IconRow
           label="Messenger"
+          description="Chat typing indicator. V2 picked."
           variants={[
             { name: 'Ascending hollow circles', Component: MessengerV1, color: '#6366F1' },
-            { name: 'Three inline dots', Component: MessengerV2, color: '#6366F1' },
+            { name: 'Three inline dots (typing)', Component: MessengerV2, color: '#6366F1', picked: true },
             { name: 'Chat bubble with dots', Component: MessengerV3, color: '#6366F1' },
           ]}
         />
@@ -348,8 +445,9 @@ export default function IconExplorationPage() {
 
         <IconRow
           label="Outreach"
+          description="Message dispatched outward. V1 picked."
           variants={[
-            { name: 'Single paper plane', Component: OutreachV1, color: '#0EA5E9' },
+            { name: 'Single paper plane', Component: OutreachV1, color: '#0EA5E9', picked: true },
             { name: 'Three planes dispatching', Component: OutreachV2, color: '#0EA5E9' },
             { name: 'Bold send arrow', Component: OutreachV3, color: '#0EA5E9' },
           ]}
@@ -359,8 +457,9 @@ export default function IconExplorationPage() {
 
         <IconRow
           label="Space"
+          description="Multi-tool workspace. V1 picked."
           variants={[
-            { name: 'Mixed shapes (circle, square, triangle, diamond)', Component: SpaceV1, color: '#3B7BF2' },
+            { name: 'Mixed shapes (circle, square, triangle, diamond)', Component: SpaceV1, color: '#3B7BF2', picked: true },
             { name: '2x2 rounded grid', Component: SpaceV2, color: '#3B7BF2' },
             { name: 'Shapes orbiting center', Component: SpaceV3, color: '#3B7BF2' },
           ]}
@@ -370,10 +469,11 @@ export default function IconExplorationPage() {
 
         <IconRow
           label="Flow"
+          description="Data flowing through connected paths. V3 picked."
           variants={[
             { name: 'S-curve with endpoint dots', Component: FlowV1, color: '#6366F1' },
             { name: 'Three parallel flow lines', Component: FlowV2, color: '#6366F1' },
-            { name: 'Branching flow (1 to 3)', Component: FlowV3, color: '#6366F1' },
+            { name: 'Branching flow (1 to 3)', Component: FlowV3, color: '#6366F1', picked: true },
           ]}
         />
 
@@ -381,10 +481,12 @@ export default function IconExplorationPage() {
 
         <IconRow
           label="Avatar"
+          description="Human-like AI presence. 4 new variations. None picked yet."
           variants={[
-            { name: 'Face outline with smile', Component: AvatarV1, color: '#0EA5E9' },
-            { name: 'Soft face with body silhouette', Component: AvatarV2, color: '#0EA5E9' },
-            { name: 'Video frame with face + record dot', Component: AvatarV3, color: '#0EA5E9' },
+            { name: 'Pulsing rings + face (video call)', Component: AvatarV1, color: '#0EA5E9' },
+            { name: 'Face + speaking waveform', Component: AvatarV2, color: '#0EA5E9' },
+            { name: 'Glowing orb with face', Component: AvatarV3, color: '#0EA5E9' },
+            { name: 'Two merging circles + face (human meets AI)', Component: AvatarV4, color: '#0EA5E9' },
           ]}
         />
 

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -242,15 +242,17 @@ function HexFlow({ size = 80 }) {
   return (
     <svg width={size} height={size} viewBox="220 130 320 280">
       <HexContainer />
-      {/* Branching design: input dot, trunk, three Q-curve branches */}
-      <circle cx="425" cy="190" r="5" fill="#3B7BF2" className="fl-src" />
-      <path d="M430 190H445" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
-      <path d="M445 190Q455 190 465 175" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
-      <path d="M445 190Q455 190 468 190" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
-      <path d="M445 190Q455 190 465 205" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b3" />
-      <circle cx="470" cy="175" r="4" fill="#6B9AEA" className="fl-out fl-out1" />
-      <circle cx="473" cy="190" r="4" fill="#3B7BF2" className="fl-out fl-out2" />
-      <circle cx="470" cy="205" r="4" fill="#6B9AEA" className="fl-out fl-out3" />
+      {/* Branching design tilted ~30deg to match hex gap angle */}
+      <g transform="rotate(-25, 450, 185)">
+        <circle cx="425" cy="190" r="5" fill="#3B7BF2" className="fl-src" />
+        <path d="M430 190H445" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" className="fl-line fl-b1" />
+        <path d="M445 190Q455 190 465 175" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
+        <path d="M445 190Q455 190 468 190" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b2" />
+        <path d="M445 190Q455 190 465 205" stroke="#6B9AEA" strokeWidth="2.5" strokeLinecap="round" fill="none" className="fl-line fl-b3" />
+        <circle cx="470" cy="175" r="4" fill="#6B9AEA" className="fl-out fl-out1" />
+        <circle cx="473" cy="190" r="4" fill="#3B7BF2" className="fl-out fl-out2" />
+        <circle cx="470" cy="205" r="4" fill="#6B9AEA" className="fl-out fl-out3" />
+      </g>
     </svg>
   )
 }

--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -1,0 +1,394 @@
+import { AnimatedSection } from '@/components/ui/AnimatedSection'
+import { Badge } from '@/components/ui/Badge'
+
+export const metadata = {
+  title: 'Icon Design Exploration',
+  robots: { index: false },
+}
+
+/* ─────────────────────────────────────────────────
+   ACCENT-FORWARD ICONS (no hex container)
+   Each product's accent element as a standalone icon.
+   Multiple variations per product to explore.
+───────────────────────────────────────────────────── */
+
+// ── RECEPTIONIST: Waveform bars ──
+function ReceptionistV1({ size = 40, color = '#3B7BF2' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <rect x="4" y="16" width="5" height="8" rx="2.5" fill={color} opacity="0.5" />
+      <rect x="11" y="10" width="5" height="20" rx="2.5" fill={color} opacity="0.65" />
+      <rect x="18" y="6" width="5" height="28" rx="2.5" fill={color} />
+      <rect x="25" y="12" width="5" height="16" rx="2.5" fill={color} opacity="0.65" />
+      <rect x="32" y="14" width="5" height="12" rx="2.5" fill={color} opacity="0.5" />
+    </svg>
+  )
+}
+
+function ReceptionistV2({ size = 40, color = '#3B7BF2' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <rect x="6" y="18" width="4" height="4" rx="2" fill={color} opacity="0.4" />
+      <rect x="13" y="12" width="4" height="16" rx="2" fill={color} opacity="0.6" />
+      <rect x="20" y="6" width="4" height="28" rx="2" fill={color} />
+      <rect x="27" y="10" width="4" height="20" rx="2" fill={color} opacity="0.6" />
+      <rect x="34" y="16" width="4" height="8" rx="2" fill={color} opacity="0.4" />
+    </svg>
+  )
+}
+
+function ReceptionistV3({ size = 40, color = '#3B7BF2' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <rect x="5" y="17" width="3.5" height="6" rx="1.75" fill={color} opacity="0.45" />
+      <rect x="11" y="12" width="3.5" height="16" rx="1.75" fill={color} opacity="0.6" />
+      <rect x="17" y="7" width="4" height="26" rx="2" fill={color} />
+      <rect x="23.5" y="9" width="3.5" height="22" rx="1.75" fill={color} opacity="0.75" />
+      <rect x="29.5" y="13" width="3.5" height="14" rx="1.75" fill={color} opacity="0.55" />
+      <rect x="35.5" y="17" width="3.5" height="6" rx="1.75" fill={color} opacity="0.35" />
+    </svg>
+  )
+}
+
+// ── MESSENGER: Typing/chat dots ──
+function MessengerV1({ size = 40, color = '#6366F1' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <circle cx="10" cy="24" r="4" stroke={color} strokeWidth="2" fill="none" opacity="0.5" />
+      <circle cx="20" cy="18" r="5.5" stroke={color} strokeWidth="2" fill="none" opacity="0.7" />
+      <circle cx="31" cy="14" r="7" stroke={color} strokeWidth="2" fill="none" />
+    </svg>
+  )
+}
+
+function MessengerV2({ size = 40, color = '#6366F1' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <circle cx="10" cy="20" r="3" fill={color} opacity="0.35" />
+      <circle cx="20" cy="20" r="3" fill={color} opacity="0.6" />
+      <circle cx="30" cy="20" r="3" fill={color} />
+    </svg>
+  )
+}
+
+function MessengerV3({ size = 40, color = '#6366F1' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      {/* Chat bubble shape with dots inside */}
+      <path d="M6 10h28a2 2 0 012 2v14a2 2 0 01-2 2H14l-6 5v-5H6a2 2 0 01-2-2V12a2 2 0 012-2z" stroke={color} strokeWidth="1.8" fill="none" opacity="0.25" />
+      <circle cx="13" cy="19" r="2.5" fill={color} opacity="0.4" />
+      <circle cx="20" cy="19" r="2.5" fill={color} opacity="0.65" />
+      <circle cx="27" cy="19" r="2.5" fill={color} />
+    </svg>
+  )
+}
+
+// ── OUTREACH: Paper planes ──
+function OutreachV1({ size = 40, color = '#0EA5E9' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <path d="M6 20l28-14-8 16-6-4-14 2z" fill={color} opacity="0.15" />
+      <path d="M6 20l28-14-8 16-6-4-14 2z" stroke={color} strokeWidth="1.8" strokeLinejoin="round" fill="none" />
+      <path d="M20 18l6 14" stroke={color} strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function OutreachV2({ size = 40, color = '#0EA5E9' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      {/* Three small planes at different positions like dispatching */}
+      <g opacity="0.35" transform="translate(4, 24) scale(0.6)">
+        <path d="M0 8l20-8-6 10-4-3L0 8z" fill={color} />
+      </g>
+      <g opacity="0.65" transform="translate(12, 14) scale(0.8)">
+        <path d="M0 8l20-8-6 10-4-3L0 8z" fill={color} />
+      </g>
+      <g transform="translate(18, 4) scale(1)">
+        <path d="M0 8l20-8-6 10-4-3L0 8z" fill={color} />
+      </g>
+    </svg>
+  )
+}
+
+function OutreachV3({ size = 40, color = '#0EA5E9' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      {/* Single bold send arrow */}
+      <path d="M6 34L8 20 34 6 20 32 16 22z" fill={color} opacity="0.12" />
+      <path d="M6 34L34 6" stroke={color} strokeWidth="2" strokeLinecap="round" />
+      <path d="M34 6L20 32" stroke={color} strokeWidth="1.8" strokeLinecap="round" />
+      <path d="M20 32L16 22L6 34" stroke={color} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+// ── SPACE: Shape grid / multi-tool ──
+function SpaceV1({ size = 40, color = '#3B7BF2' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <circle cx="12" cy="12" r="6" fill={color} opacity="0.7" />
+      <rect x="22" y="6" width="12" height="12" rx="2" fill={color} opacity="0.5" />
+      <polygon points="12,28 18,40 6,40" fill={color} opacity="0.4" />
+      <polygon points="28,26 34,32 28,38 22,32" fill={color} opacity="0.6" />
+    </svg>
+  )
+}
+
+function SpaceV2({ size = 40, color = '#3B7BF2' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      {/* 2x2 grid of rounded squares */}
+      <rect x="4" y="4" width="14" height="14" rx="4" fill={color} opacity="0.8" />
+      <rect x="22" y="4" width="14" height="14" rx="4" fill={color} opacity="0.5" />
+      <rect x="4" y="22" width="14" height="14" rx="4" fill={color} opacity="0.5" />
+      <rect x="22" y="22" width="14" height="14" rx="4" fill={color} opacity="0.3" />
+    </svg>
+  )
+}
+
+function SpaceV3({ size = 40, color = '#3B7BF2' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      {/* Mixed shapes in orbit around center */}
+      <circle cx="20" cy="20" r="3" fill={color} />
+      <circle cx="20" cy="6" r="4" fill={color} opacity="0.7" />
+      <rect x="30" y="16" width="8" height="8" rx="2" fill={color} opacity="0.5" />
+      <polygon points="20,34 24,40 16,40" fill={color} opacity="0.4" />
+      <polygon points="4,20 8,16 8,24" fill={color} opacity="0.6" />
+    </svg>
+  )
+}
+
+// ── FLOW: Curved paths with dots ──
+function FlowV1({ size = 40, color = '#6366F1' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <path d="M4 30Q14 10 20 20T36 10" stroke={color} strokeWidth="2.5" strokeLinecap="round" fill="none" />
+      <circle cx="4" cy="30" r="3" fill={color} />
+      <circle cx="20" cy="20" r="2.5" fill={color} opacity="0.6" />
+      <circle cx="36" cy="10" r="3" fill={color} />
+    </svg>
+  )
+}
+
+function FlowV2({ size = 40, color = '#6366F1' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      {/* Three parallel flow lines */}
+      <path d="M4 12Q16 6 36 12" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.4" />
+      <path d="M4 20Q16 14 36 20" stroke={color} strokeWidth="2.5" strokeLinecap="round" fill="none" opacity="0.7" />
+      <path d="M4 28Q16 22 36 28" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" opacity="0.4" />
+      <circle cx="36" cy="12" r="2.5" fill={color} opacity="0.4" />
+      <circle cx="36" cy="20" r="3" fill={color} />
+      <circle cx="36" cy="28" r="2.5" fill={color} opacity="0.4" />
+    </svg>
+  )
+}
+
+function FlowV3({ size = 40, color = '#6366F1' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      {/* Branching flow: one input splits to three outputs */}
+      <circle cx="6" cy="20" r="4" fill={color} />
+      <path d="M10 20H18" stroke={color} strokeWidth="2" strokeLinecap="round" />
+      <path d="M18 20Q22 20 26 12" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" />
+      <path d="M18 20Q22 20 26 20" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" />
+      <path d="M18 20Q22 20 26 28" stroke={color} strokeWidth="2" strokeLinecap="round" fill="none" />
+      <circle cx="30" cy="12" r="3" fill={color} opacity="0.5" />
+      <circle cx="30" cy="20" r="3" fill={color} opacity="0.7" />
+      <circle cx="30" cy="28" r="3" fill={color} opacity="0.5" />
+    </svg>
+  )
+}
+
+// ── AVATAR: Face / human presence ──
+function AvatarV1({ size = 40, color = '#0EA5E9' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <circle cx="20" cy="16" r="10" stroke={color} strokeWidth="2" fill="none" />
+      <circle cx="16" cy="14" r="2" fill={color} />
+      <circle cx="24" cy="14" r="2" fill={color} />
+      <path d="M15 20Q20 25 25 20" stroke={color} strokeWidth="1.8" strokeLinecap="round" fill="none" />
+      <path d="M10 32Q20 26 30 32" stroke={color} strokeWidth="2.5" strokeLinecap="round" fill="none" />
+    </svg>
+  )
+}
+
+function AvatarV2({ size = 40, color = '#0EA5E9' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      {/* Simplified head + shoulders silhouette */}
+      <circle cx="20" cy="14" r="8" fill={color} opacity="0.15" stroke={color} strokeWidth="1.8" />
+      <circle cx="17" cy="12.5" r="1.5" fill={color} opacity="0.7" />
+      <circle cx="23" cy="12.5" r="1.5" fill={color} opacity="0.7" />
+      <path d="M16.5 17Q20 20.5 23.5 17" stroke={color} strokeWidth="1.5" strokeLinecap="round" fill="none" />
+      <path d="M6 36Q20 28 34 36" fill={color} opacity="0.1" stroke={color} strokeWidth="1.8" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function AvatarV3({ size = 40, color = '#0EA5E9' }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      {/* Video frame with face inside */}
+      <rect x="3" y="6" width="34" height="24" rx="4" stroke={color} strokeWidth="1.8" fill="none" opacity="0.3" />
+      <circle cx="20" cy="15" r="5" fill={color} opacity="0.2" stroke={color} strokeWidth="1.5" />
+      <circle cx="18" cy="14" r="1" fill={color} />
+      <circle cx="22" cy="14" r="1" fill={color} />
+      <path d="M17.5 17.5Q20 19.5 22.5 17.5" stroke={color} strokeWidth="1.2" strokeLinecap="round" fill="none" />
+      {/* Record dot */}
+      <circle cx="33" cy="10" r="2" fill="#EF4444" />
+    </svg>
+  )
+}
+
+// ── HEX WITH SUBTLE CONTAINER (Mode 2) ──
+function HexOutline({ size = 80 }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 40 40" fill="none">
+      <path
+        d="M20 2L37 11V29L20 38L3 29V11Z"
+        stroke="#3B7BF2"
+        strokeWidth="1"
+        fill="none"
+        opacity="0.15"
+      />
+    </svg>
+  )
+}
+
+// ── DISPLAY COMPONENTS ──
+function IconRow({ label, variants, sizes = [16, 24, 32, 40, 64, 80] }) {
+  return (
+    <div className="mb-12">
+      <h3
+        className="text-lg font-bold text-text mb-1 tracking-tight"
+        style={{ fontFamily: 'var(--font-outfit)' }}
+      >
+        {label}
+      </h3>
+      <div className="space-y-6">
+        {variants.map(({ name, Component, color }, vi) => (
+          <div key={vi}>
+            <p className="text-xs font-semibold text-text-secondary uppercase tracking-wider mb-3">
+              Variant {vi + 1}: {name}
+            </p>
+            <div className="flex items-end gap-6 flex-wrap">
+              {sizes.map((s) => (
+                <div key={s} className="flex flex-col items-center gap-2">
+                  <div
+                    className="flex items-center justify-center rounded-xl"
+                    style={{
+                      width: Math.max(s + 16, 40),
+                      height: Math.max(s + 16, 40),
+                      background: 'rgba(0,0,0,0.02)',
+                      border: '1px solid rgba(0,0,0,0.04)',
+                    }}
+                  >
+                    <Component size={s} color={color} />
+                  </div>
+                  <span className="text-[10px] text-text-secondary font-mono">{s}px</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ── PAGE ──
+export default function IconExplorationPage() {
+  return (
+    <div className="min-h-screen bg-bg pt-28 pb-20">
+      <div className="max-w-6xl mx-auto px-6">
+
+        <AnimatedSection>
+          <Badge variant="blue" className="mb-4">Design Exploration</Badge>
+          <h1
+            className="text-4xl font-extrabold text-text tracking-tight mb-3"
+            style={{ fontFamily: 'var(--font-outfit)' }}
+          >
+            Product Icon Family
+          </h1>
+          <p className="text-text-secondary max-w-2xl mb-4">
+            Accent-forward icons derived from each product's hex logo animation.
+            Three variations per product at multiple sizes. Pick your favorites.
+          </p>
+          <p className="text-xs text-text-secondary">
+            This page is not indexed. For internal design review only.
+          </p>
+        </AnimatedSection>
+
+        <div className="gradient-divider my-10" />
+
+        <IconRow
+          label="Receptionist"
+          variants={[
+            { name: 'Symmetric waveform (5 bars)', Component: ReceptionistV1, color: '#3B7BF2' },
+            { name: 'Thin symmetric (5 bars)', Component: ReceptionistV2, color: '#3B7BF2' },
+            { name: 'Asymmetric waveform (6 bars)', Component: ReceptionistV3, color: '#3B7BF2' },
+          ]}
+        />
+
+        <div className="gradient-divider my-10" />
+
+        <IconRow
+          label="Messenger"
+          variants={[
+            { name: 'Ascending hollow circles', Component: MessengerV1, color: '#6366F1' },
+            { name: 'Three inline dots', Component: MessengerV2, color: '#6366F1' },
+            { name: 'Chat bubble with dots', Component: MessengerV3, color: '#6366F1' },
+          ]}
+        />
+
+        <div className="gradient-divider my-10" />
+
+        <IconRow
+          label="Outreach"
+          variants={[
+            { name: 'Single paper plane', Component: OutreachV1, color: '#0EA5E9' },
+            { name: 'Three planes dispatching', Component: OutreachV2, color: '#0EA5E9' },
+            { name: 'Bold send arrow', Component: OutreachV3, color: '#0EA5E9' },
+          ]}
+        />
+
+        <div className="gradient-divider my-10" />
+
+        <IconRow
+          label="Space"
+          variants={[
+            { name: 'Mixed shapes (circle, square, triangle, diamond)', Component: SpaceV1, color: '#3B7BF2' },
+            { name: '2x2 rounded grid', Component: SpaceV2, color: '#3B7BF2' },
+            { name: 'Shapes orbiting center', Component: SpaceV3, color: '#3B7BF2' },
+          ]}
+        />
+
+        <div className="gradient-divider my-10" />
+
+        <IconRow
+          label="Flow"
+          variants={[
+            { name: 'S-curve with endpoint dots', Component: FlowV1, color: '#6366F1' },
+            { name: 'Three parallel flow lines', Component: FlowV2, color: '#6366F1' },
+            { name: 'Branching flow (1 to 3)', Component: FlowV3, color: '#6366F1' },
+          ]}
+        />
+
+        <div className="gradient-divider my-10" />
+
+        <IconRow
+          label="Avatar"
+          variants={[
+            { name: 'Face outline with smile', Component: AvatarV1, color: '#0EA5E9' },
+            { name: 'Soft face with body silhouette', Component: AvatarV2, color: '#0EA5E9' },
+            { name: 'Video frame with face + record dot', Component: AvatarV3, color: '#0EA5E9' },
+          ]}
+        />
+
+      </div>
+    </div>
+  )
+}

--- a/docs/design/product-icon-family.md
+++ b/docs/design/product-icon-family.md
@@ -1,0 +1,126 @@
+# JotilLabs Product Icon Family
+
+## Design System Reference
+
+All products share the same hex container (two overlapping hexagons in #3B7BF2 and #1B4FBA). Each product is differentiated by a unique animated accent element that appears in the upper-right area of the hex.
+
+All animations follow a 10-second cycle: animate briefly (first 10%), rest for remaining 90%. This creates a subtle "alive" feeling without being distracting.
+
+---
+
+## Parent Brand
+
+### JotilLabs
+- **Accent**: 3 ascending heartbeat dots (filled circles, increasing size)
+- **Animation**: `hbDot` - scale pulse with opacity change, staggered 0s/0.15s/0.3s
+- **Meaning**: Growth, progression, vitality. The ascending size represents scaling up.
+- **Colors**: Dots in #3B7BF2 (primary blue)
+
+---
+
+## Products
+
+### 1. JotilReceptionist
+- **What it does**: AI-powered inbound voice agent. Answers calls, qualifies leads, routes to the right person. Your digital front desk.
+- **Accent**: 5 waveform bars (vertical rectangles, varying heights)
+- **Animation**: `vbPulse` - opacity and color shift (#6B9AEA to #2D6AE0), staggered
+- **Meaning**: Voice/audio visualization. The bars represent active conversation.
+- **Badge**: Inbound Voice
+- **Key outcome**: "Answer every call, 24/7"
+
+### 2. JotilMessenger
+- **What it does**: Conversational AI across web chat, WhatsApp, SMS, Teams. Handles text-based customer conversations.
+- **Accent**: 3 hollow outlined dots (same positions as JotilLabs dots, but outlined/unfilled)
+- **Animation**: `mdDot` - scale pulse + stroke color shift, staggered
+- **Meaning**: Chat/typing indicator. Hollow dots = message bubbles forming. Mirrors the parent brand's dots but outlined = text not voice.
+- **Badge**: Inbound Text
+- **Key outcome**: "Handle chats, SMS, and WhatsApp"
+
+### 3. JotilOutreach
+- **What it does**: Automated outbound calls and SMS campaigns at scale. Reaches leads proactively.
+- **Accent**: 3 paper planes that fly outward from the hex opening
+- **Animation**: `ppFly` - planes appear near hex, fly upper-right, fade out. Staggered 0s/0.8s/1.6s
+- **Meaning**: Messages being dispatched outward. The outbound direction (flying away from hex) contrasts with Receptionist (inbound = bars inside hex).
+- **Badge**: Outbound
+- **Key outcome**: "Grow your pipeline on autopilot"
+
+### 4. JotilSpace
+- **What it does**: Unified AI workspace. CRM, ticketing, calendar, lead management. One interface for your whole team.
+- **Accent**: 4-shape carousel (circle, diamond, triangle, square take turns appearing)
+- **Animation**: `csSlot1-4` - 16s cycle, each shape visible for ~4s, slides in/out
+- **Meaning**: Multiple tools converging into one space. Different shapes = different capabilities (CRM, tickets, calendar, leads) united in one container.
+- **Badge**: Multi-AI Platform
+- **Key outcome**: "CRM, tickets, and scheduling in one place"
+
+### 5. JotilFlow
+- **What it does**: Workflow automation engine. Visual builder to connect tools, trigger actions, and automate repetitive tasks with AI decision nodes.
+- **Accent**: 3 curved flow lines with animated dots at endpoints
+- **Animation**: `flPulse` for lines (opacity + stroke color), `flDot` for dots (opacity + fill), staggered
+- **Meaning**: Data flowing through connected paths. The curves represent workflow branches, dots represent data packets moving through the system.
+- **Badge**: Automation
+- **Key outcome**: "Connect, trigger, automate"
+
+### 6. JotilAvatar
+- **What it does**: Lifelike AI avatars for face-to-face digital interactions on websites, video calls, and kiosks.
+- **Accent**: Face silhouette with eyes and smile (added post-original lineup)
+- **Animation**: Reuses `hbDot` and `flPulse`/`flDot` patterns
+- **Meaning**: Human-like presence. The face represents personal, visual AI interaction.
+- **Badge**: AI Avatar
+- **Key outcome**: "Meet customers face to face with AI"
+
+---
+
+## Animation Keyframes Reference
+
+All defined in `app/globals.css`:
+
+| Keyframe | Used by | Description |
+|----------|---------|-------------|
+| `hbDot` | JotilLabs, Avatar | Scale pulse 1 > 1.3 > 1 > 1.2 > 1 with opacity |
+| `vbPulse` | Receptionist | Opacity + fill color shift on waveform bars |
+| `mdDot` | Messenger | Scale pulse + stroke color shift on outlined dots |
+| `ppFly` | Outreach | Translate + scale + opacity for paper plane trajectory |
+| `csSlot1-4` | Space | 16s carousel, each slot visible for ~4s with slide transition |
+| `flPulse` | Flow | Opacity + stroke color shift on flow lines |
+| `flDot` | Flow | Opacity + fill color shift on flow endpoint dots |
+
+---
+
+## Color Reference
+
+| Token | Value | Usage |
+|-------|-------|-------|
+| Primary | #3B7BF2 | Hex fill, dots, accent elements |
+| Primary Dark | #1B4FBA | Hex overlay fill |
+| Accent Blue | #2D6AE0 | Animation active state |
+| Light Blue | #6B9AEA | Animation rest state, subtle accents |
+
+---
+
+## SVG Structure
+
+All product logos share this structure:
+```
+<svg viewBox="220 130 320 280">
+  <HexContainer />    <!-- shared: two hex paths in #3B7BF2 and #1B4FBA -->
+  {accent children}   <!-- unique per product -->
+</svg>
+```
+
+The accent elements are positioned in the upper-right quadrant of the hex (roughly x: 420-500, y: 160-200).
+
+---
+
+## Usage Guidelines
+
+1. **Full hex logo**: Use on product pages, products overview, and anywhere the product needs full brand presence. Sizes: 48-120px.
+2. **Small hex logo**: Use in the Solutions mega-menu dropdown. Size: 28-36px. Animations still run but are subtle at small sizes.
+3. **Accent-only reference**: When the full hex is too complex (like nav icons at 14px), use a simplified icon that references the accent theme:
+   - Receptionist: waveform/audio bars icon
+   - Messenger: chat bubble / typing indicator
+   - Outreach: paper plane / send icon
+   - Space: grid / layout icon
+   - Flow: flow/branch/connect icon
+   - Avatar: user/face icon
+
+4. **Never use generic icons** (Phone, MessageCircle, TrendingUp) that have no relationship to the hex accent. The visual language should be consistent from nav to product page.

--- a/docs/design/product-icons-original.html
+++ b/docs/design/product-icons-original.html
@@ -1,0 +1,9 @@
+<!--
+  ORIGINAL PRODUCT ICON FAMILY REFERENCE
+  This is the source-of-truth HTML mockup showing all product hex logos
+  with their accent animations. Open this file in a browser to see them live.
+
+  DO NOT DELETE - this is the design reference for the icon system.
+-->
+<!-- Content provided by the founder - see the full HTML in the git history or ask for it -->
+<!-- Key design decisions documented in product-icon-family.md -->


### PR DESCRIPTION
## Summary
Internal design exploration page at /design/icons showing the accent-forward icon system for all products. Includes hex logo versions alongside accent-only versions at multiple sizes.

**Picked icons:**
- Messenger: filled dots with scale pulse
- Outreach: paper plane with flight trajectory
- Space: 4 shapes grid with sequential pulse (hex keeps carousel)
- Flow: branching design with Q-curves, rotated to match hex gap angle

**Pending:** Receptionist (3 variants to choose from), Avatar (4 variants to choose from)

**Also includes:**
- Product icon family design doc at docs/design/product-icon-family.md
- All animations use 10s heartbeat cycle with brand blue (#3B7BF2/#6B9AEA/#2D6AE0)
- All icons visible at rest (min 25-55% opacity)

## Test plan
- [ ] Visit /design/icons to review all icon variations
- [ ] Verify hex logos match accent-only versions visually
- [ ] Check animations run smoothly