### PR TITLE
fix: brand drift cleanup (headings, gradients, nav copy, CTA, light wash)

### DIFF
--- a/app/design/icons/page.jsx
+++ b/app/design/icons/page.jsx
@@ -274,7 +274,7 @@ function HexAvatar({ size = 80 }) {
 function IconRow({ label, description, variants, hexComponent: HexComp, sizes = [16, 24, 32, 40, 64] }) {
   return (
     <div className="mb-16">
-      <h3 className="text-xl font-bold text-text mb-1 tracking-tight" style={{ fontFamily: 'var(--font-outfit)' }}>{label}</h3>
+      <h3 className="text-xl font-bold text-text mb-1 tracking-tight" style={{ fontFamily: 'var(--font-display)' }}>{label}</h3>
       {description && <p className="text-sm text-text-secondary mb-6">{description}</p>}
       {HexComp && (
         <div className="mb-8">
@@ -483,7 +483,7 @@ export default function IconExplorationPage() {
       <div className="max-w-6xl mx-auto px-6">
         <AnimatedSection>
           <Badge variant="blue" className="mb-4">Design Exploration v4</Badge>
-          <h1 className="text-4xl font-extrabold text-text tracking-tight mb-3" style={{ fontFamily: 'var(--font-outfit)' }}>
+          <h1 className="text-4xl font-extrabold text-text tracking-tight mb-3" style={{ fontFamily: 'var(--font-display)' }}>
             Product Icon Family
           </h1>
           <p className="text-text-secondary max-w-2xl">

--- a/app/globals.css
+++ b/app/globals.css
@@ -316,6 +316,63 @@ h1, h2, h3, h4, h5, h6 {
   background: linear-gradient(135deg, rgba(56, 89, 168, 0.10), rgba(34, 211, 238, 0.08));
 }
 
+/* Brand light wash - subtle blue-lavender gradient + grain (use on hero areas) */
+.bg-brand-wash {
+  position: relative;
+  background: linear-gradient(135deg, #EEF2FB 0%, #FAFBFD 45%, #E8EEFA 100%);
+}
+.bg-brand-wash::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.2 0 0 0 0 0.2 0 0 0 0 0.4 0 0 0 0.6 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  opacity: 0.04;
+  mix-blend-mode: multiply;
+  z-index: 0;
+}
+.bg-brand-wash > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* Brand light wash with faint isometric hex watermark (homepage hero) */
+.bg-brand-wash-mark {
+  position: relative;
+  background: linear-gradient(135deg, #EEF2FB 0%, #FAFBFD 45%, #E8EEFA 100%);
+}
+.bg-brand-wash-mark::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0.2 0 0 0 0 0.2 0 0 0 0 0.4 0 0 0 0.6 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  opacity: 0.04;
+  mix-blend-mode: multiply;
+  z-index: 0;
+}
+.bg-brand-wash-mark::after {
+  content: "";
+  position: absolute;
+  top: 5%;
+  right: -5%;
+  width: 520px;
+  height: 520px;
+  pointer-events: none;
+  background-image:
+    url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='220 130 320 280'%3E%3Cg fill='%233859a8'%3E%3Cpath d='M341.48 360.32 c-21.48 -12.68 -59.08 -34.74 -84 -49.33 l-6.82 -3.96 0 -67.36 0 -67.36 3.15 -2.49 c3.44 -2.79 17.52 -11.07 20.08 -11.87 l1.69 -0.44 0 67.36 0 67.43 6.82 3.96 c79.09 46.40 83.48 48.96 84.88 48.96 0.66 0 4.25 -1.83 7.99 -4.10 3.81 -2.27 8.43 -4.98 10.41 -6.01 6.60 -3.66 7.55 -4.25 10.70 -6.23 1.76 -1.10 4.03 -2.35 5.13 -2.79 1.10 -0.44 4.10 -2.20 6.74 -3.88 2.64 -1.76 8.21 -5.13 12.46 -7.55 4.25 -2.42 11.36 -6.60 15.83 -9.24 4.54 -2.64 8.65 -4.91 9.16 -5.06 0.59 -0.07 3.59 -1.83 6.67 -3.88 l5.64 -3.66 0.07 -44.12 0 -44.20 2.79 -1.39 c1.47 -0.73 6.16 -3.44 10.33 -5.94 4.25 -2.49 8.58 -4.69 9.75 -4.91 l2.05 -0.37 0 57.90 0 57.98 -1.61 0.88z'/%3E%3C/g%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: contain;
+  opacity: 0.04;
+  z-index: 0;
+}
+.bg-brand-wash-mark > * {
+  position: relative;
+  z-index: 1;
+}
+
 .gradient-divider {
   height: 1px;
   background: linear-gradient(90deg, transparent, rgba(59, 123, 242, 0.2), rgba(99, 102, 241, 0.15), transparent);

--- a/app/globals.css
+++ b/app/globals.css
@@ -302,18 +302,18 @@ h1, h2, h3, h4, h5, h6 {
 /* ── Gradients ── */
 
 .text-gradient {
-  background: linear-gradient(135deg, #3B7BF2, #6366F1, #0EA5E9);
+  background: linear-gradient(135deg, #3859a8, #22D3EE);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
 
 .btn-gradient {
-  background: linear-gradient(135deg, #3B7BF2, #2D6AE0);
+  background: linear-gradient(135deg, #3859a8, #2a4688);
 }
 
 .icon-gradient-bg {
-  background: linear-gradient(135deg, rgba(59, 123, 242, 0.1), rgba(99, 102, 241, 0.08));
+  background: linear-gradient(135deg, rgba(56, 89, 168, 0.10), rgba(34, 211, 238, 0.08));
 }
 
 .gradient-divider {

--- a/app/not-found.jsx
+++ b/app/not-found.jsx
@@ -21,13 +21,13 @@ export default function NotFound() {
       <div className="relative z-10 text-center max-w-lg">
         <p
           className="text-gradient font-extrabold tracking-tight mb-4"
-          style={{ fontSize: 'clamp(5rem, 12vw, 8rem)', lineHeight: 1, fontFamily: 'var(--font-outfit)' }}
+          style={{ fontSize: 'clamp(5rem, 12vw, 8rem)', lineHeight: 1, fontFamily: 'var(--font-display)' }}
         >
           404
         </p>
         <h1
           className="text-2xl sm:text-3xl font-bold text-text tracking-tight mb-4"
-          style={{ fontFamily: 'var(--font-outfit)' }}
+          style={{ fontFamily: 'var(--font-display)' }}
         >
           Page not found
         </h1>

--- a/app/products/[slug]/page.jsx
+++ b/app/products/[slug]/page.jsx
@@ -105,14 +105,14 @@ export default async function ProductPage({ params }) {
               <Badge variant="blue" className="mb-5">{product.badge}</Badge>
               <h1
                 className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-text tracking-tight leading-[1.07] mb-5"
-                style={{ fontFamily: 'var(--font-outfit)', fontWeight: 800 }}
+                style={{ fontFamily: 'var(--font-display)', fontWeight: 800 }}
               >
                 {product.displayName[0]}
                 <span className="text-gradient">{product.displayName[1]}</span>
               </h1>
               <p
                 className="text-xl font-semibold text-text-secondary mb-4"
-                style={{ fontFamily: 'var(--font-outfit)' }}
+                style={{ fontFamily: 'var(--font-display)' }}
               >
                 {product.tagline}
               </p>
@@ -166,7 +166,7 @@ export default async function ProductPage({ params }) {
             <p className="text-xs font-semibold uppercase tracking-widest text-primary mb-3">What you get</p>
             <h2
               className="text-3xl font-bold text-text tracking-tight"
-              style={{ fontFamily: 'var(--font-outfit)' }}
+              style={{ fontFamily: 'var(--font-display)' }}
             >
               What&apos;s included
             </h2>
@@ -184,7 +184,7 @@ export default async function ProductPage({ params }) {
                 <div className="card-premium h-full flex flex-col">
                   <h3
                     className="text-lg font-bold text-text mb-3"
-                    style={{ fontFamily: 'var(--font-outfit)' }}
+                    style={{ fontFamily: 'var(--font-display)' }}
                   >
                     {svc.name}
                   </h3>
@@ -222,7 +222,7 @@ export default async function ProductPage({ params }) {
             <p className="text-xs font-semibold uppercase tracking-widest text-primary mb-3">Why it works</p>
             <h2
               className="text-3xl font-bold text-text tracking-tight"
-              style={{ fontFamily: 'var(--font-outfit)' }}
+              style={{ fontFamily: 'var(--font-display)' }}
             >
               Built for results
             </h2>
@@ -239,7 +239,7 @@ export default async function ProductPage({ params }) {
                     </IconBox>
                     <h3
                       className="text-base font-semibold text-text mb-2"
-                      style={{ fontFamily: 'var(--font-outfit)' }}
+                      style={{ fontFamily: 'var(--font-display)' }}
                     >
                       {feat.title}
                     </h3>
@@ -261,7 +261,7 @@ export default async function ProductPage({ params }) {
             <p className="text-xs font-semibold uppercase tracking-widest text-primary mb-3">Pricing</p>
             <h2
               className="text-3xl font-bold text-text tracking-tight"
-              style={{ fontFamily: 'var(--font-outfit)' }}
+              style={{ fontFamily: 'var(--font-display)' }}
             >
               Simple, transparent pricing
             </h2>
@@ -294,7 +294,7 @@ export default async function ProductPage({ params }) {
             <p className="text-xs font-semibold uppercase tracking-widest text-primary mb-4">Get Started</p>
             <h2
               className="text-3xl sm:text-4xl font-extrabold text-text tracking-tight mb-4"
-              style={{ fontFamily: 'var(--font-outfit)' }}
+              style={{ fontFamily: 'var(--font-display)' }}
             >
               Ready to try{' '}
               <span className="text-gradient">{product.name}</span>?

--- a/app/products/[slug]/pricing/page.jsx
+++ b/app/products/[slug]/pricing/page.jsx
@@ -103,7 +103,7 @@ export default async function ProductPricingPage({ params }) {
             </Badge>
             <h1
               className="text-4xl sm:text-5xl font-extrabold text-text tracking-tight leading-[1.07] mb-5"
-              style={{ fontFamily: 'var(--font-outfit)', fontWeight: 800 }}
+              style={{ fontFamily: 'var(--font-display)', fontWeight: 800 }}
             >
               Simple pricing.{' '}
               <span className="text-gradient">Every call handled.</span>
@@ -162,7 +162,7 @@ export default async function ProductPricingPage({ params }) {
               </p>
               <h2
                 className="text-3xl font-bold text-text tracking-tight"
-                style={{ fontFamily: 'var(--font-outfit)' }}
+                style={{ fontFamily: 'var(--font-display)' }}
               >
                 Everything at a glance
               </h2>
@@ -189,7 +189,7 @@ export default async function ProductPricingPage({ params }) {
           <AnimatedSection>
             <h2
               className="text-3xl sm:text-4xl font-extrabold text-text tracking-tight mb-4"
-              style={{ fontFamily: 'var(--font-outfit)' }}
+              style={{ fontFamily: 'var(--font-display)' }}
             >
               Ready to try{' '}
               <span className="text-gradient">{product.name}</span>?

--- a/app/products/page.jsx
+++ b/app/products/page.jsx
@@ -73,7 +73,7 @@ export default function ProductsPage() {
             <Badge variant="blue" className="mb-5">Our Solutions</Badge>
             <h1
               className="text-4xl sm:text-5xl lg:text-6xl font-extrabold text-text tracking-tight leading-[1.08]"
-              style={{ fontFamily: 'var(--font-outfit)' }}
+              style={{ fontFamily: 'var(--font-display)' }}
             >
               Everything your business needs.{' '}
               <span className="text-gradient">One platform.</span>
@@ -116,7 +116,7 @@ export default function ProductsPage() {
             <p className="text-xs font-semibold uppercase tracking-widest text-primary mb-3">What we offer</p>
             <h2
               className="text-3xl font-bold text-text tracking-tight"
-              style={{ fontFamily: 'var(--font-outfit)' }}
+              style={{ fontFamily: 'var(--font-display)' }}
             >
               Explore our solutions
             </h2>
@@ -139,7 +139,7 @@ export default function ProductsPage() {
                         <div className="flex items-center gap-2 flex-wrap mb-1.5">
                           <h3
                             className="text-xl font-bold text-text"
-                            style={{ fontFamily: 'var(--font-outfit)' }}
+                            style={{ fontFamily: 'var(--font-display)' }}
                           >
                             {product.name}
                           </h3>
@@ -201,7 +201,7 @@ export default function ProductsPage() {
             <p className="text-xs font-semibold uppercase tracking-widest text-primary mb-3">Compare</p>
             <h2
               className="text-3xl font-bold text-text tracking-tight"
-              style={{ fontFamily: 'var(--font-outfit)' }}
+              style={{ fontFamily: 'var(--font-display)' }}
             >
               Which solution fits your business?
             </h2>
@@ -227,7 +227,7 @@ export default function ProductsPage() {
                               <Logo size={28} />
                               <span
                                 className="text-xs font-semibold text-text whitespace-nowrap"
-                                style={{ fontFamily: 'var(--font-outfit)' }}
+                                style={{ fontFamily: 'var(--font-display)' }}
                               >
                                 {p.displayName[1]}
                               </span>
@@ -277,7 +277,7 @@ export default function ProductsPage() {
           <AnimatedSection>
             <h2
               className="text-3xl font-bold text-text tracking-tight mb-4"
-              style={{ fontFamily: 'var(--font-outfit)' }}
+              style={{ fontFamily: 'var(--font-display)' }}
             >
               Not sure which product fits?
             </h2>

--- a/components/layout/Navbar.jsx
+++ b/components/layout/Navbar.jsx
@@ -17,7 +17,7 @@ import { products } from '@/data/products'
 
 // Derive nav items from centralized product data
 const PRODUCT_ITEMS = products.map((p) => ({
-  name: p.shortName,
+  name: p.name,
   slug: p.slug,
   description: p.oneLiner,
   icon: LucideIcons[p.icon] || LucideIcons.Sparkles,

--- a/components/pricing/FeatureComparison.jsx
+++ b/components/pricing/FeatureComparison.jsx
@@ -20,7 +20,7 @@ export function FeatureComparison({ tiers, features }) {
               >
                 <div
                   className="text-base font-bold"
-                  style={{ fontFamily: 'var(--font-outfit)' }}
+                  style={{ fontFamily: 'var(--font-display)' }}
                 >
                   {tier.name}
                 </div>

--- a/components/pricing/PricingCard.jsx
+++ b/components/pricing/PricingCard.jsx
@@ -23,7 +23,7 @@ export function PricingCard({ tier, ctaHref = '/contact' }) {
       )}
       <p
         className="text-xl font-bold text-text mb-1"
-        style={{ fontFamily: 'var(--font-outfit)' }}
+        style={{ fontFamily: 'var(--font-display)' }}
       >
         {tier.name}
       </p>
@@ -32,7 +32,7 @@ export function PricingCard({ tier, ctaHref = '/contact' }) {
       <div className="mb-6 flex items-end gap-1">
         <span
           className={`text-4xl font-extrabold tracking-tight ${isHighlighted ? 'text-primary' : 'text-text'}`}
-          style={{ fontFamily: 'var(--font-outfit)' }}
+          style={{ fontFamily: 'var(--font-display)' }}
         >
           {tier.price}
         </span>

--- a/components/product/DemoVisualization.jsx
+++ b/components/product/DemoVisualization.jsx
@@ -14,7 +14,7 @@ import {
 /* ================================================================
    Shared styles / constants
    ================================================================ */
-const headingFont = { fontFamily: 'var(--font-outfit)' }
+const headingFont = { fontFamily: 'var(--font-display)' }
 const monoFont = { fontFamily: 'var(--font-jetbrains)' }
 
 const cardEntry = {

--- a/components/product/FAQAccordion.jsx
+++ b/components/product/FAQAccordion.jsx
@@ -15,7 +15,7 @@ export function FAQAccordion({ faq }) {
           <p className="text-xs font-semibold uppercase tracking-widest text-primary mb-3">FAQ</p>
           <h2
             className="text-3xl font-bold text-text tracking-tight"
-            style={{ fontFamily: 'var(--font-outfit)' }}
+            style={{ fontFamily: 'var(--font-display)' }}
           >
             Common questions
           </h2>
@@ -36,7 +36,7 @@ export function FAQAccordion({ faq }) {
                   >
                     <span
                       className="text-base font-semibold text-text"
-                      style={{ fontFamily: 'var(--font-outfit)' }}
+                      style={{ fontFamily: 'var(--font-display)' }}
                     >
                       {item.question}
                     </span>

--- a/components/sections/CTASection.jsx
+++ b/components/sections/CTASection.jsx
@@ -10,46 +10,59 @@ export function CTASection() {
     <section
       className="relative py-24 overflow-hidden"
       style={{
-        background: 'linear-gradient(135deg, #3B7BF2 0%, #1B4FBA 50%, #6366F1 100%)',
+        background: 'linear-gradient(180deg, #3859a8 0%, #2a4688 45%, #0f1129 100%)',
       }}
     >
-      {/* Dot pattern overlay */}
+      {/* Brand grain noise overlay */}
       <div
         aria-hidden="true"
         className="pointer-events-none absolute inset-0"
         style={{
           backgroundImage:
-            'radial-gradient(circle, rgba(255,255,255,0.12) 1px, transparent 1px)',
-          backgroundSize: '28px 28px',
-          maskImage: 'radial-gradient(ellipse 80% 80% at 50% 50%, black 40%, transparent 100%)',
-          WebkitMaskImage:
-            'radial-gradient(ellipse 80% 80% at 50% 50%, black 40%, transparent 100%)',
+            "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.5 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
+          opacity: 0.06,
+          mixBlendMode: 'overlay',
         }}
       />
 
-      {/* Ambient glow orbs */}
+      {/* Dot pattern overlay (sparse, for texture) */}
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute rounded-full"
+        className="pointer-events-none absolute inset-0"
         style={{
-          width: 500,
-          height: 500,
-          top: '-20%',
-          right: '-10%',
-          background: 'radial-gradient(circle, rgba(99,102,241,0.35) 0%, transparent 70%)',
-          filter: 'blur(80px)',
+          backgroundImage:
+            'radial-gradient(circle, rgba(255,255,255,0.10) 1px, transparent 1px)',
+          backgroundSize: '28px 28px',
+          maskImage: 'radial-gradient(ellipse 80% 70% at 50% 40%, black 40%, transparent 100%)',
+          WebkitMaskImage:
+            'radial-gradient(ellipse 80% 70% at 50% 40%, black 40%, transparent 100%)',
         }}
       />
+
+      {/* Cyan ambient glow - top right, matches brand doc */}
       <div
         aria-hidden="true"
         className="pointer-events-none absolute rounded-full"
         style={{
-          width: 400,
-          height: 400,
-          bottom: '-15%',
-          left: '-8%',
-          background: 'radial-gradient(circle, rgba(59,123,242,0.30) 0%, transparent 70%)',
-          filter: 'blur(80px)',
+          width: 520,
+          height: 520,
+          top: '-25%',
+          right: '-12%',
+          background: 'radial-gradient(circle, rgba(34,211,238,0.28) 0%, transparent 70%)',
+          filter: 'blur(90px)',
+        }}
+      />
+      {/* Royal blue secondary glow - left */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute rounded-full"
+        style={{
+          width: 420,
+          height: 420,
+          top: '10%',
+          left: '-10%',
+          background: 'radial-gradient(circle, rgba(56,89,168,0.35) 0%, transparent 70%)',
+          filter: 'blur(90px)',
         }}
       />
 

--- a/components/sections/CTASection.jsx
+++ b/components/sections/CTASection.jsx
@@ -72,7 +72,7 @@ export function CTASection() {
             />
             <span
               className="text-[11px] font-semibold text-white tracking-[0.1em] uppercase"
-              style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif', opacity: 0.9 }}
+              style={{ fontFamily: 'var(--font-display)', opacity: 0.9 }}
             >
               Get started today
             </span>
@@ -84,7 +84,7 @@ export function CTASection() {
           <h2
             className="text-white font-extrabold tracking-[-0.04em] mb-6"
             style={{
-              fontFamily: 'var(--font-outfit), Outfit, sans-serif',
+              fontFamily: 'var(--font-display)',
               fontSize: 'clamp(2rem, 4.5vw, 3.25rem)',
               lineHeight: 1.1,
             }}
@@ -117,7 +117,7 @@ export function CTASection() {
               href="/contact"
               className="inline-flex items-center gap-2 no-underline text-sm font-semibold rounded-[11px] px-6 py-3.5 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
               style={{
-                fontFamily: 'var(--font-outfit), Outfit, sans-serif',
+                fontFamily: 'var(--font-display)',
                 background: '#FFFFFF',
                 color: 'var(--color-primary)',
                 boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
@@ -132,7 +132,7 @@ export function CTASection() {
               href="/products/receptionist"
               className="inline-flex items-center gap-2 no-underline text-sm font-semibold text-white rounded-[11px] px-6 py-3.5 transition-all duration-200 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-primary"
               style={{
-                fontFamily: 'var(--font-outfit), Outfit, sans-serif',
+                fontFamily: 'var(--font-display)',
                 background: 'rgba(255,255,255,0.12)',
                 border: '1px solid rgba(255,255,255,0.22)',
                 backdropFilter: 'blur(12px)',

--- a/components/sections/Hero.jsx
+++ b/components/sections/Hero.jsx
@@ -91,7 +91,7 @@ export function Hero() {
   useEffect(() => setMounted(true), [])
 
   return (
-    <section className="relative min-h-screen flex items-center overflow-hidden pt-20">
+    <section className="bg-brand-wash-mark relative min-h-screen flex items-center overflow-hidden pt-20">
       {/* Background gradient mesh */}
       <div className="pointer-events-none absolute inset-0" aria-hidden="true">
         {/* Soft grid pattern */}

--- a/components/sections/Hero.jsx
+++ b/components/sections/Hero.jsx
@@ -132,7 +132,7 @@ export function Hero() {
                   animate={{ y: 0, opacity: 1 }}
                   transition={{ duration: 0.65, delay: 0.1 + i * 0.1, ease: [0.22, 1, 0.36, 1] }}
                   className={`block leading-[1.05] tracking-[-0.04em] font-extrabold ${i === 2 ? 'text-gradient' : 'text-text'}`}
-                  style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif', fontSize: 'clamp(2.75rem, 5.5vw, 4.25rem)' }}
+                  style={{ fontFamily: 'var(--font-display)', fontSize: 'clamp(2.75rem, 5.5vw, 4.25rem)' }}
                 >
                   {line}
                 </motion.span>
@@ -162,7 +162,7 @@ export function Hero() {
               <Link
                 href="/contact"
                 className="inline-flex items-center gap-2 no-underline text-sm font-semibold text-white btn-gradient px-6 py-3.5 rounded-[11px] shadow-lg shadow-primary/30 hover:shadow-xl hover:shadow-primary/40 hover:-translate-y-0.5 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2"
-                style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif' }}
+                style={{ fontFamily: 'var(--font-display)' }}
               >
                 Book a Demo
                 <ArrowRight size={15} strokeWidth={2} />
@@ -170,7 +170,7 @@ export function Hero() {
               <Link
                 href="/products"
                 className="inline-flex items-center gap-2 no-underline text-sm font-semibold text-text px-6 py-3.5 rounded-[11px] transition-all duration-300 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 focus-visible:ring-offset-2"
-                style={{ background: 'rgba(0,0,0,0.04)', border: '1px solid rgba(0,0,0,0.07)', fontFamily: 'var(--font-outfit), Outfit, sans-serif' }}
+                style={{ background: 'rgba(0,0,0,0.04)', border: '1px solid rgba(0,0,0,0.07)', fontFamily: 'var(--font-display)' }}
               >
                 See How It Works
               </Link>

--- a/components/sections/HowItWorks.jsx
+++ b/components/sections/HowItWorks.jsx
@@ -41,7 +41,7 @@ export function HowItWorks() {
           <p className="badge mx-auto mb-4 w-fit">How it works</p>
           <h2
             className="text-[clamp(1.9rem,3.5vw,2.75rem)] font-extrabold tracking-[-0.04em] text-text mb-4"
-            style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif' }}
+            style={{ fontFamily: 'var(--font-display)' }}
           >
             Up and running in{' '}
             <span className="text-gradient">hours, not months</span>
@@ -144,7 +144,7 @@ function StepCard({ step, index }) {
       <div>
         <h3
           className="text-lg font-bold text-text mb-2 tracking-[-0.025em]"
-          style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif' }}
+          style={{ fontFamily: 'var(--font-display)' }}
         >
           {title}
         </h3>

--- a/components/sections/IntegrationStrip.jsx
+++ b/components/sections/IntegrationStrip.jsx
@@ -101,7 +101,7 @@ export function IntegrationStrip() {
           <p className="badge mx-auto mb-4 w-fit">Integrations</p>
           <h2
             className="text-[clamp(1.9rem,3.5vw,2.75rem)] font-extrabold tracking-[-0.04em] text-text mb-4"
-            style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif' }}
+            style={{ fontFamily: 'var(--font-display)' }}
           >
             Works with{' '}
             <span className="text-gradient">150+ tools</span>{' '}

--- a/components/sections/LogoCloud.jsx
+++ b/components/sections/LogoCloud.jsx
@@ -34,7 +34,7 @@ export function LogoCloud() {
           className="text-center text-[11px] font-semibold tracking-[0.14em] uppercase mb-8"
           style={{
             color: 'var(--color-text-secondary)',
-            fontFamily: 'var(--font-outfit), Outfit, sans-serif',
+            fontFamily: 'var(--font-display)',
           }}
         >
           Trusted by forward-thinking businesses
@@ -98,7 +98,7 @@ function LogoItem({ name }) {
           className="text-[10px] font-bold"
           style={{
             color: 'var(--color-primary)',
-            fontFamily: 'var(--font-outfit), Outfit, sans-serif',
+            fontFamily: 'var(--font-display)',
             letterSpacing: '0.03em',
           }}
         >
@@ -109,7 +109,7 @@ function LogoItem({ name }) {
       {/* Name */}
       <span
         style={{
-          fontFamily: 'var(--font-outfit), Outfit, sans-serif',
+          fontFamily: 'var(--font-display)',
           fontSize: 13,
           fontWeight: 600,
           letterSpacing: '-0.01em',

--- a/components/sections/ProductShowcase.jsx
+++ b/components/sections/ProductShowcase.jsx
@@ -61,7 +61,7 @@ export function ProductShowcase() {
           </p>
           <h2
             className="text-[clamp(1.9rem,3.5vw,2.75rem)] font-extrabold tracking-[-0.04em] text-text mb-4"
-            style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif' }}
+            style={{ fontFamily: 'var(--font-display)' }}
           >
             One platform.{' '}
             <span className="text-gradient">Every customer touchpoint.</span>
@@ -89,7 +89,7 @@ export function ProductShowcase() {
           <Link
             href="/products"
             className="inline-flex items-center gap-2 text-sm font-semibold text-primary no-underline group"
-            style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif' }}
+            style={{ fontFamily: 'var(--font-display)' }}
           >
             See how it all works together
             <ArrowRight
@@ -144,7 +144,7 @@ function CapabilityCard({ capability }) {
         {/* Title */}
         <h3
           className="text-lg font-bold text-text mb-2 leading-tight tracking-[-0.02em]"
-          style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif' }}
+          style={{ fontFamily: 'var(--font-display)' }}
         >
           {title}
         </h3>

--- a/components/sections/Stats.jsx
+++ b/components/sections/Stats.jsx
@@ -54,7 +54,7 @@ export function Stats() {
             className="text-[11px] font-semibold tracking-[0.14em] uppercase"
             style={{
               color: 'var(--color-text-secondary)',
-              fontFamily: 'var(--font-outfit), Outfit, sans-serif',
+              fontFamily: 'var(--font-display)',
             }}
           >
             Results that speak for themselves
@@ -108,7 +108,7 @@ function StatCard({ stat }) {
       <div>
         <p
           className="text-[clamp(2rem,4vw,2.75rem)] font-extrabold leading-none tracking-[-0.04em] text-gradient"
-          style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif' }}
+          style={{ fontFamily: 'var(--font-display)' }}
         >
           <CountUp end={end} suffix={suffix} decimals={decimals} duration={2.2} />
         </p>

--- a/components/sections/Testimonials.jsx
+++ b/components/sections/Testimonials.jsx
@@ -42,7 +42,7 @@ export function Testimonials() {
           <p className="badge mx-auto mb-4 w-fit">Testimonials</p>
           <h2
             className="text-[clamp(1.9rem,3.5vw,2.75rem)] font-extrabold tracking-[-0.04em] text-text"
-            style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif' }}
+            style={{ fontFamily: 'var(--font-display)' }}
           >
             What our{' '}
             <span className="text-gradient">clients say</span>
@@ -107,7 +107,7 @@ function TestimonialCard({ testimonial }) {
           className="w-9 h-9 rounded-full flex items-center justify-center shrink-0 text-white text-xs font-bold"
           style={{
             background: `linear-gradient(135deg, ${avatarColor}, ${avatarColor}cc)`,
-            fontFamily: 'var(--font-outfit), Outfit, sans-serif',
+            fontFamily: 'var(--font-display)',
             letterSpacing: '0.02em',
           }}
         >
@@ -117,7 +117,7 @@ function TestimonialCard({ testimonial }) {
         <div>
           <p
             className="text-[13px] font-semibold text-text leading-none tracking-[-0.01em]"
-            style={{ fontFamily: 'var(--font-outfit), Outfit, sans-serif' }}
+            style={{ fontFamily: 'var(--font-display)' }}
           >
             {name}
           </p>

--- a/data/products.js
+++ b/data/products.js
@@ -6,7 +6,7 @@ export const products = [
     shortName: 'Receptionist',
     icon: 'Phone',
     iconColor: '#3B7BF2',
-    oneLiner: 'Answer every call, 24/7',
+    oneLiner: 'AI-powered inbound voice agent. Your digital front desk.',
     tagline: 'Your AI Front Desk. Never Miss a Call Again',
     badge: 'Inbound Voice',
     description:
@@ -150,7 +150,7 @@ export const products = [
     shortName: 'Messenger',
     icon: 'MessageCircle',
     iconColor: '#6366F1',
-    oneLiner: 'Handle chats, SMS, and WhatsApp',
+    oneLiner: 'Conversational AI across web chat, WhatsApp, SMS, Teams.',
     tagline: 'Conversational AI Across Every Text Channel',
     badge: 'Inbound Text',
     description:
@@ -212,7 +212,7 @@ export const products = [
     shortName: 'Outreach',
     icon: 'TrendingUp',
     iconColor: '#0EA5E9',
-    oneLiner: 'Grow your pipeline on autopilot',
+    oneLiner: 'Automated outbound calls and SMS campaigns at scale.',
     tagline: 'AI-Powered Outbound Campaigns at Scale',
     badge: 'Outbound',
     description:
@@ -274,7 +274,7 @@ export const products = [
     shortName: 'Space',
     icon: 'LayoutGrid',
     iconColor: '#3B7BF2',
-    oneLiner: 'CRM, tickets, and scheduling in one place',
+    oneLiner: "Your team's AI workspace. Multiple AI models, one interface.",
     tagline: 'Your Team\'s Unified AI Workspace',
     badge: 'Multi-AI Platform',
     description:
@@ -347,7 +347,7 @@ export const products = [
     shortName: 'Flow',
     icon: 'GitBranch',
     iconColor: '#6366F1',
-    oneLiner: 'Automate any workflow visually',
+    oneLiner: 'Custom workflow automation engine. Connect, trigger, act.',
     tagline: 'Custom Workflow Automation Engine',
     badge: 'Automation',
     description:


### PR DESCRIPTION
## Summary
Fixes four brand-drift issues found after the rebrand merge.

## Closes
Closes #30 Closes #31 Closes #32 Closes #33

## Commits
- `eb2e922` fix(brand): replace var(--font-outfit) with --font-display and update gradient utilities to new palette
- `6a33589` feat(nav): use full JotilX product names and new marketing oneLiners in Solutions dropdown
- `b0f9b51` fix(cta): replace old-palette gradient with brand navy gradient + grain, end in footer navy
- `f4a1b8e` feat(bg): add brand-wash light gradient utilities + apply watermark wash to homepage hero

## What changed
- 18 section/product files: all inline `var(--font-outfit)` references swapped to `var(--font-display)`. Headings now render in Montserrat Alternates (were falling back to system-ui).
- `globals.css` gradient utilities (`.text-gradient`, `.btn-gradient`, `.icon-gradient-bg`) now use brand palette (royal blue + cyan), not old bright blue + indigo.
- Solutions nav dropdown shows full JotilX names (JotilReceptionist, JotilMessenger, etc.) with the new marketing oneLiners.
- CTA section gradient fixed: royal to navy to match footer seamlessly, with brand grain overlay and cyan ambient glow (matches brand doc).
- New `.bg-brand-wash` and `.bg-brand-wash-mark` utilities in `globals.css` for light-theme branded backgrounds. Applied to homepage Hero.

## Test plan
- [ ] Vercel preview URL: verify all section headings are in Montserrat Alternates (rounded terminals)
- [ ] "Every customer touchpoint" text gradient is blue-to-cyan, not indigo
- [ ] Solutions nav dropdown shows JotilReceptionist, JotilMessenger, ... with new copy
- [ ] Bottom of homepage: CTA fades into footer with no hard edge
- [ ] Homepage hero has subtle cool gradient + faint watermark + grain