### PR TITLE
feat(theme): PR A2 — card / surface / interaction refresh

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -99,6 +99,16 @@
   --animate-ring-rotate: ring-rotate 60s linear infinite;
   --animate-orbit: orbit 25s linear infinite;
   --animate-heartbeat: heartbeat 10s ease-in-out infinite;
+
+  /* Interaction tokens — shared duration + easing so every transition on
+     the site feels authored by one hand. Consume via var(--duration-*)
+     and var(--ease-*) in transition: declarations. */
+  --duration-micro:          200ms;  /* hover ring, color shift, small state */
+  --duration-card-lift:      300ms;  /* card translateY + shadow */
+  --duration-section-reveal: 600ms;  /* on-scroll section entry */
+  --ease-micro:  cubic-bezier(0, 0, 0.2, 1);         /* ease-out */
+  --ease-card:   cubic-bezier(0.22, 1, 0.36, 1);     /* soft landing */
+  --ease-reveal: cubic-bezier(0.22, 1, 0.36, 1);     /* same — semantic alias */
 }
 
 /* ── Keyframes ── */
@@ -270,7 +280,9 @@ h1, h2, h3, h4, h5, h6 {
   font-family: var(--font-display);
 }
 
-/* ── Glass System ── */
+/* ── Glass System ──
+   Frosted floating panels (e.g. Hero VoiceOrb). Matches card language
+   for hover feel — same tokens, same timing. */
 
 .glass {
   background: rgba(255, 255, 255, 0.6);
@@ -278,58 +290,81 @@ h1, h2, h3, h4, h5, h6 {
   -webkit-backdrop-filter: blur(24px) saturate(180%);
   border: 1px solid rgba(255, 255, 255, 0.5);
   box-shadow:
-    0 8px 32px rgba(0, 0, 0, 0.06),
-    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+    0 8px 32px rgba(15, 17, 41, 0.06),
+    inset 0 1px 0 rgba(255, 255, 255, 0.85);
 }
 
 .glass-hover {
-  transition: all 0.2s ease;
+  transition:
+    border-color var(--duration-micro) var(--ease-micro),
+    box-shadow var(--duration-card-lift) var(--ease-card),
+    transform var(--duration-card-lift) var(--ease-card);
 }
 
 .glass-hover:hover {
-  border-color: rgba(56, 89, 168, 0.15);
+  border-color: var(--color-primary-200);
   box-shadow:
-    0 16px 48px rgba(56, 89, 168, 0.08),
-    0 4px 16px rgba(0, 0, 0, 0.06),
-    inset 0 1px 0 rgba(255, 255, 255, 0.9);
+    0 16px 48px rgba(56, 89, 168, 0.10),
+    0 4px 16px rgba(15, 17, 41, 0.05),
+    inset 0 1px 0 rgba(255, 255, 255, 0.95);
   transform: translateY(-2px);
 }
 
 .glass-dark {
   background: rgba(15, 17, 41, 0.04);
-  border: 1px solid rgba(15, 17, 41, 0.06);
+  border: 1px solid rgba(15, 17, 41, 0.08);
   border-radius: 12px;
 }
 
-/* ── Card System ── */
+/* ── Card System ──
+   Surface gradient + inner highlight + primary-tinted border replaces
+   the flat white rectangle. card-premium adds a cyan glow halo on hover
+   to distinguish elevated cards. */
 
 .card {
-  background: #FFFFFF;
-  border: 1px solid rgba(0, 0, 0, 0.05);
+  background: linear-gradient(180deg, #FFFFFF 0%, #FAFBFD 100%);
+  border: 1px solid var(--color-primary-100);
   border-radius: 20px;
   padding: 32px;
-  transition: all 0.3s ease;
+  box-shadow:
+    var(--shadow-sm),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  transition:
+    border-color var(--duration-micro) var(--ease-micro),
+    box-shadow var(--duration-card-lift) var(--ease-card),
+    transform var(--duration-card-lift) var(--ease-card);
 }
 
 .card:hover {
-  box-shadow: 0 8px 32px rgba(56, 89, 168, 0.08);
+  border-color: var(--color-primary-200);
+  box-shadow:
+    var(--shadow-lg),
+    inset 0 1px 0 rgba(255, 255, 255, 0.9);
   transform: translateY(-2px);
-  border-color: rgba(56, 89, 168, 0.12);
 }
 
 .card-premium {
-  background: #FFFFFF;
-  border: 1px solid rgba(0, 0, 0, 0.05);
+  background: linear-gradient(180deg, #FFFFFF 0%, #FAFBFD 100%);
+  border: 1px solid var(--color-primary-100);
   border-radius: 20px;
   padding: 32px;
   position: relative;
-  transition: all 0.3s ease;
+  box-shadow:
+    var(--shadow-sm),
+    inset 0 1px 0 rgba(255, 255, 255, 0.8);
+  transition:
+    border-color var(--duration-micro) var(--ease-micro),
+    box-shadow var(--duration-card-lift) var(--ease-card),
+    transform var(--duration-card-lift) var(--ease-card);
 }
 
 .card-premium:hover {
+  border-color: var(--color-primary-300);
+  box-shadow:
+    var(--shadow-xl),
+    var(--shadow-glow-cyan),
+    inset 0 1px 0 rgba(255, 255, 255, 0.95);
   transform: translateY(-2px);
-  box-shadow: 0 20px 56px rgba(56, 89, 168, 0.1), 0 4px 16px rgba(0, 0, 0, 0.04);
-  border-color: rgba(56, 89, 168, 0.15);
 }
 
 .card-premium::before {
@@ -345,11 +380,11 @@ h1, h2, h3, h4, h5, h6 {
   mask-composite: exclude;
   pointer-events: none;
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity var(--duration-card-lift) var(--ease-card);
 }
 
 .card-premium:hover::before {
-  background: linear-gradient(135deg, rgba(56, 89, 168, 0.3), rgba(34, 211, 238, 0.2), rgba(34, 211, 238, 0.3));
+  background: linear-gradient(135deg, rgba(56, 89, 168, 0.4), rgba(34, 211, 238, 0.3), rgba(56, 89, 168, 0.4));
   opacity: 1;
 }
 
@@ -485,7 +520,7 @@ button:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
-  outline: 2px solid rgba(56, 89, 168, 0.5);
+  outline: 2px solid rgba(34, 211, 238, 0.6);
   outline-offset: 2px;
   border-radius: 4px;
 }
@@ -559,6 +594,62 @@ textarea:focus-visible {
 .opsz-display {
   font-optical-sizing: auto;
   font-variation-settings: "opsz" 144;
+}
+
+/* ── Surface Variants ──
+   Four role-based section backgrounds. Defined here in Phase A2, not yet
+   applied to any section — Phase A3 will add the className to sections
+   (LogoCloud, Testimonials, Stats, CTASection, etc.) to produce the
+   cool/warm/dark rhythm planned in docs/plans/2026-04-21-theme-refresh-
+   and-phased-redesign.md §2.3. */
+
+.surface-raised {
+  background: linear-gradient(180deg, #FFFFFF 0%, var(--color-primary-50) 100%);
+}
+
+.surface-sunken {
+  background-color: var(--color-primary-50);
+}
+
+.surface-warm {
+  background-color: var(--color-warm);
+}
+
+.surface-navy {
+  background-color: var(--color-navy);
+  color: var(--color-white);
+}
+.surface-navy h1,
+.surface-navy h2,
+.surface-navy h3,
+.surface-navy h4,
+.surface-navy h5,
+.surface-navy h6 {
+  color: var(--color-white);
+}
+.surface-navy p,
+.surface-navy li {
+  color: rgba(255, 255, 255, 0.78);
+}
+.surface-navy a:not(.btn-gradient):not([class*="bg-"]) {
+  color: var(--color-accent);
+}
+.surface-navy .card,
+.surface-navy .card-premium {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06) 0%, rgba(255, 255, 255, 0.02) 100%);
+  border-color: rgba(255, 255, 255, 0.08);
+  color: var(--color-white);
+  box-shadow:
+    0 1px 2px rgba(0, 0, 0, 0.2),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+.surface-navy .card:hover,
+.surface-navy .card-premium:hover {
+  border-color: rgba(34, 211, 238, 0.35);
+  box-shadow:
+    0 12px 32px rgba(0, 0, 0, 0.35),
+    var(--shadow-glow-cyan),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
 /* Respect prefers-reduced-motion across all custom motion */


### PR DESCRIPTION
## Summary

Second PR of the Phase A theme refresh. All changes in a single file — `app/globals.css` — no JSX or component edits. This is the surface-and-depth upgrade that makes baseline pages feel intentional before A3 applies section atmospherics.

**5 things shipped:**

1. **Interaction tokens** added to `@theme`:
   - `--duration-micro` (200ms), `--duration-card-lift` (300ms), `--duration-section-reveal` (600ms)
   - `--ease-micro`, `--ease-card`, `--ease-reveal` (shared cubic-beziers)
   - Cards and glass now use these tokens instead of inline `0.3s ease`.

2. **`.card` / `.card-premium` refresh** — visible depth without layout shift:
   - Surface gradient replaces flat white (`#FFFFFF → #FAFBFD` diagonal)
   - Border: `--color-primary-100` (subtle primary tint) instead of black-rgba
   - Inner highlight for "light-from-above" luminance edge
   - Resting: `--shadow-sm`. Hover: `--shadow-lg` (`.card`) or `--shadow-xl + --shadow-glow-cyan` halo (`.card-premium`)
   - Hover border escalates from primary-200 → primary-300 on premium

3. **`.glass` / `.glass-hover` / `.glass-dark` refresh** — aligned with card timing + palette. Shadows navy-tinted instead of black.

4. **Focus ring switched to cyan** (`rgba(34, 211, 238, 0.6)`) on `a/button/input/textarea:focus-visible`. Reads more premium. `::selection` stayed navy-tinted (already correct from A1).

5. **Four surface variant classes added** (defined, unused in this PR — A3 consumes them):
   - `.surface-raised` — white-to-primary-50 gradient
   - `.surface-sunken` — solid primary-50
   - `.surface-warm` — `--color-warm` cream
   - `.surface-navy` — dark navy with nested adjustments for headings, text, and cards inside (dark-card styling activates automatically when parent is `.surface-navy`)

## What's out of scope

- Applying surface variants to any section — that's PR A3
- `AtmosphericDivider` / `GrainOverlay` / `ScrollGradientMesh` sitewide — PR A3
- Typography editorial moments (Fraunces usage) — optional PR A4
- Any JSX or component markup changes

## Test plan

- [x] `npm run lint:colors` — OK
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run test:visual` — 58/58 passing (card/focus shifts stayed within Playwright tolerance, no baseline regeneration)
- [ ] Reviewer: `npm run dev` and hover over any `.card` / `.card-premium` on the pricing page or product pages — confirm (a) visible surface gradient, (b) inner highlight edge, (c) navy-tinted shadow replaces old black shadow, (d) on `.card-premium` hover, cyan glow halo appears
- [ ] Reviewer: keyboard-Tab through homepage CTAs — confirm focus ring is now cyan
- [ ] Reviewer: DevTools `:root` — confirm `--duration-micro`, `--duration-card-lift`, `--ease-card`, `--ease-reveal` defined
- [ ] Reviewer: legal pages (`/terms`, `/privacy`, `/opt-in`) — content reads correctly, no regression

## Closes / references

- Closes #74
- Refs #73 (PR A1 — depends on tonal scale)
- Refs #71 (Phase 1 primitives — consumes `--shadow-*-brand` + `--shadow-glow-cyan`)
- Plan doc: `docs/plans/2026-04-21-theme-refresh-and-phased-redesign.md` §2.2