### PR TITLE
feat(theme): PR A3 — section atmospherics applied sitewide

### DIFF
--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -8,6 +8,7 @@ import { Footer } from '@/components/layout/Footer'
 import { OrganizationJsonLd, WebsiteJsonLd } from '@/components/layout/JsonLd'
 import { AIWidget } from '@/components/widgets/AIWidget'
 import { ScrollToTop } from '@/components/layout/ScrollToTop'
+import { GrainOverlay } from '@/components/design'
 
 const montserratAlternates = Montserrat_Alternates({
   subsets: ['latin'],
@@ -116,11 +117,19 @@ export default function RootLayout({ children }) {
         )}
       </head>
       <body className="min-h-screen bg-bg text-text antialiased" suppressHydrationWarning>
+        {/* Global grain texture — fixed to viewport, z-behind everything.
+            Provides subliminal depth to every surface site-wide at 2.5%. */}
+        <div
+          aria-hidden="true"
+          className="pointer-events-none fixed inset-0 z-0"
+        >
+          <GrainOverlay tone="light" opacity={0.025} />
+        </div>
         <a href="#main-content" className="skip-to-main">
           Skip to main content
         </a>
         <Navbar />
-        <main id="main-content">{children}</main>
+        <main id="main-content" className="relative z-10">{children}</main>
         <Footer />
         <ScrollToTop />
         <AIWidget />

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -6,6 +6,7 @@ import { Stats } from '@/components/sections/Stats'
 import { Testimonials } from '@/components/sections/Testimonials'
 import { IntegrationStrip } from '@/components/sections/IntegrationStrip'
 import { CTASection } from '@/components/sections/CTASection'
+import { AtmosphericDivider } from '@/components/design'
 
 export const metadata = {
   title: 'JotilLabs - AI Voice, Chat & Automation Platform',
@@ -13,16 +14,45 @@ export const metadata = {
     'Never miss a customer again. JotilLabs AI voice agents, chatbots, and SMS automation handle your calls, chats, leads, and workflows 24/7.',
 }
 
+// Surface color references — keep in sync with app/globals.css @theme tokens.
+// Used only by the AtmosphericDividers on this page to bleed from one
+// section's bottom color into the next section's top color.
+const BG = 'var(--color-bg)'
+const WARM = 'var(--color-warm)'
+const SUNKEN = 'var(--color-primary-50)'
+const NAVY = 'var(--color-navy)'
+const PRIMARY = 'var(--color-primary)'
+
 export default function Home() {
   return (
     <>
       <Hero />
+      {/* Hero wash → warm cream (LogoCloud) */}
+      <AtmosphericDivider from={BG} to={WARM} height={100} />
+
       <LogoCloud />
+      {/* Warm → sunken cool (ProductShowcase) */}
+      <AtmosphericDivider from={WARM} to={SUNKEN} height={100} />
+
       <ProductShowcase />
+      {/* Sunken → raised (HowItWorks) — small lift */}
+      <AtmosphericDivider from={SUNKEN} to="#FFFFFF" height={60} />
+
       <HowItWorks />
+      {/* Raised-bottom (primary-50) → sunken (primary-50) — seamless, no divider */}
+
       <Stats />
+      {/* Stats sunken → warm cream (Testimonials) */}
+      <AtmosphericDivider from={SUNKEN} to={WARM} height={100} />
+
       <Testimonials />
+      {/* Warm → raised (IntegrationStrip) */}
+      <AtmosphericDivider from={WARM} to="#FFFFFF" height={100} />
+
       <IntegrationStrip />
+      {/* Raised-bottom → navy CTASection — dramatic radial closer */}
+      <AtmosphericDivider from={SUNKEN} to={PRIMARY} height={140} direction="radial" />
+
       <CTASection />
     </>
   )

--- a/components/sections/CTASection.jsx
+++ b/components/sections/CTASection.jsx
@@ -8,7 +8,7 @@ import { AnimatedSection } from '@/components/ui/AnimatedSection'
 export function CTASection() {
   return (
     <section
-      className="relative py-24 overflow-hidden"
+      className="surface-navy relative py-24 overflow-hidden"
       style={{
         background: 'linear-gradient(180deg, #3859a8 0%, #2a4688 45%, #0f1129 100%)',
       }}

--- a/components/sections/HowItWorks.jsx
+++ b/components/sections/HowItWorks.jsx
@@ -33,7 +33,7 @@ const STEPS = [
 
 export function HowItWorks() {
   return (
-    <section className="py-24" style={{ background: '#FFFFFF' }}>
+    <section className="surface-raised py-24">
       <div className="max-w-7xl mx-auto px-6">
 
         {/* Heading */}

--- a/components/sections/IntegrationStrip.jsx
+++ b/components/sections/IntegrationStrip.jsx
@@ -93,7 +93,7 @@ export function IntegrationStrip() {
   const row2 = INTEGRATIONS.slice(10, 20)
 
   return (
-    <section className="py-24" style={{ background: 'var(--color-bg)' }}>
+    <section className="surface-raised py-24">
       <div className="max-w-7xl mx-auto px-6">
 
         {/* Heading */}

--- a/components/sections/LogoCloud.jsx
+++ b/components/sections/LogoCloud.jsx
@@ -16,14 +16,7 @@ const TRACK = [...LOGOS, ...LOGOS]
 
 export function LogoCloud() {
   return (
-    <section
-      className="py-12 overflow-hidden"
-      style={{
-        background: '#FFFFFF',
-        borderTop: '1px solid rgba(0,0,0,0.04)',
-        borderBottom: '1px solid rgba(0,0,0,0.04)',
-      }}
-    >
+    <section className="surface-warm py-12 overflow-hidden">
       <div className="max-w-7xl mx-auto px-6">
         {/* Label */}
         <motion.p

--- a/components/sections/ProductShowcase.jsx
+++ b/components/sections/ProductShowcase.jsx
@@ -51,7 +51,7 @@ const CAPABILITIES = [
 
 export function ProductShowcase() {
   return (
-    <section className="py-24" style={{ background: 'var(--color-bg)' }}>
+    <section className="surface-sunken py-24">
       <div className="max-w-7xl mx-auto px-6">
 
         {/* Heading */}

--- a/components/sections/Stats.jsx
+++ b/components/sections/Stats.jsx
@@ -42,10 +42,7 @@ const STATS = [
 
 export function Stats() {
   return (
-    <section
-      className="py-20"
-      style={{ background: 'var(--color-bg-alt)' }}
-    >
+    <section className="surface-sunken py-20">
       <div className="max-w-7xl mx-auto px-6">
 
         {/* Optional section label */}

--- a/components/sections/Testimonials.jsx
+++ b/components/sections/Testimonials.jsx
@@ -34,7 +34,7 @@ const TESTIMONIALS = [
 
 export function Testimonials() {
   return (
-    <section className="py-24" style={{ background: 'var(--color-bg)' }}>
+    <section className="surface-warm py-24">
       <div className="max-w-7xl mx-auto px-6">
 
         {/* Heading */}


### PR DESCRIPTION
## Summary

Third and final PR of Phase A. This is the one that actually looks different — baseline pages now feel authored.

**What you'll see:**
- Homepage scroll takes a deliberate path: wash → **cream** LogoCloud → **cool** ProductShowcase → **rising** HowItWorks → **cool** Stats → **cream** Testimonials → **rising** IntegrationStrip → **navy** CTASection
- Each section-to-section transition bleeds color via `AtmosphericDivider` instead of sitting on a hard line
- Every page carries a subtle grain texture from the global `GrainOverlay` mounted once in the root layout
- Card elevation (from A2) now sits on varied surfaces, so cards read differently depending on their section's surface role

**What stayed the same:**
- Hero — kept untouched; its existing four-orb atmospheric layer already does the job, and Phase C will rebuild the hero anyway
- Interior `.gradient-divider` usages on About/Products/Contact/etc. pages — those are content separators inside sections, not section-boundary transitions. Wrong tool for the job.
- Legal pages — visually unaffected beyond the global grain layer

## Per-file changes

| File | Change |
|---|---|
| `app/layout.jsx` | Mount global `GrainOverlay` (fixed, z-0, 2.5% opacity); promote `main` to z-10 |
| `app/page.jsx` | Add 6 `AtmosphericDivider` instances between homepage sections with tuned from/to and heights |
| `components/sections/LogoCloud.jsx` | Replace inline bg with `surface-warm` |
| `components/sections/ProductShowcase.jsx` | Replace inline bg with `surface-sunken` |
| `components/sections/HowItWorks.jsx` | Replace inline bg with `surface-raised` |
| `components/sections/Stats.jsx` | Replace inline bg with `surface-sunken` |
| `components/sections/Testimonials.jsx` | Replace inline bg with `surface-warm` |
| `components/sections/IntegrationStrip.jsx` | Replace inline bg with `surface-raised` |
| `components/sections/CTASection.jsx` | Add `surface-navy` class (retains custom gradient bg via inline style) |

## One deviation from the plan

Plan doc §2.3 called for `ScrollGradientMesh` inside CTASection + Hero. Both skipped in this PR:

- **Hero**: already has 4 animated gradient orbs. Adding mesh would double-layer, and Phase C will rebuild the hero fresh.
- **CTASection**: first mount made Playwright visual snapshots flaky (GPU blur variance + `useEffect` CSS var race). CTASection already has grain + dot pattern overlays and a rich navy gradient — atmospheric enough. **Follow-up issue #77** filed to stabilize the primitive before section-level reintroduction.

## Test plan

- [x] `npm run lint:colors` — OK
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run test:visual` — 58/58 stable across two consecutive runs
- [ ] Reviewer: `npm run dev`, scroll the homepage top-to-bottom. Confirm (a) cool/warm/cool/warm/navy rhythm is legible, (b) no hard 1px lines between sections, (c) navy CTASection closes the scroll dramatically, (d) cards render correctly on sunken/warm/navy surfaces
- [ ] Reviewer: DevTools Elements → confirm `<div aria-hidden class="pointer-events-none fixed inset-0 z-0">` renders in `<body>` near the top
- [ ] Reviewer: compare the homepage Before/After via the Vercel preview — this is the first PR where the difference is obvious at a glance
- [ ] Reviewer: legal pages (`/terms`, `/privacy`, `/opt-in`) still read cleanly with only the global grain affecting them
- [ ] Reviewer: mobile homepage renders cleanly; surface colors apply correctly below `md`

## Closes / references

- Closes #76
- Refs #75 (PR A2 — consumes `.surface-*` variant classes)
- Refs #73 (PR A1 — consumes tonal scale)
- Refs #71 (Phase 1 — consumes `GrainOverlay`, `AtmosphericDivider`)
- See also: #77 — follow-up for `ScrollGradientMesh` stability before re-introducing to CTASection / Hero

## What's next

Phase A is complete after this merges. Open decision for next step:

- **PR A4 (OPTIONAL)** — typography editorial moments + motion baseline tokens. Only if the site feels close-but-not-there after A3 deploys.
- **Phase B kickoff** — per-product showcases, framework + 5 product PRs. Messenger deferred.

I'll ask again once you've merged and eyeballed the deployed preview.