### PR TITLE
fix(pricing): horizontal alignment across tier cards + refined checkmarks

### DIFF
--- a/app/products/[slug]/pricing/page.jsx
+++ b/app/products/[slug]/pricing/page.jsx
@@ -158,9 +158,11 @@ export default async function ProductPricingPage({ params }) {
                 </div>
               )}
 
-              {/* Main 4-card tier grid (Starter + Pro + Business + Enterprise) */}
+              {/* Main 4-card tier grid (Starter + Pro + Business + Enterprise).
+                  auto-rows-fr forces all rows to match the tallest card so
+                  internal section min-heights align horizontally. */}
               <div
-                className={`grid grid-cols-1 md:grid-cols-2 ${gridTiers.length === 4 ? 'lg:grid-cols-4' : 'lg:grid-cols-3'} gap-6 items-stretch`}
+                className={`grid grid-cols-1 md:grid-cols-2 ${gridTiers.length === 4 ? 'lg:grid-cols-4' : 'lg:grid-cols-3'} auto-rows-fr gap-6 items-stretch`}
               >
                 {gridTiers.map((tier, i) => (
                   <AnimatedSection key={tier.slug ?? i} delay={i * 0.06}>

--- a/components/pricing/PricingCard.jsx
+++ b/components/pricing/PricingCard.jsx
@@ -43,23 +43,25 @@ export function PricingCard({ tier, productSlug, unitLabel }) {
             : 'border-primary-100 bg-white shadow-[0_1px_3px_rgba(15,17,41,0.05)]'
         }`}
       >
-        {/* Name */}
+        {/* Name — fixed row height so tier labels align across all cards */}
         <p
-          className="text-xl font-bold text-primary mb-2"
+          className="text-xl font-bold text-primary mb-2 min-h-[2rem] flex items-center"
           style={{ fontFamily: 'var(--font-display)' }}
         >
           {tier.name}
         </p>
-        {tier.description && (
-          <p className="text-sm text-text-secondary leading-relaxed mb-6 min-h-[3rem]">
-            {tier.description}
-          </p>
-        )}
 
-        {/* Price */}
-        <div className="mb-6 flex items-baseline gap-1">
+        {/* Description — min-h locks height so all following rows align
+            even when one tier has a longer description that wraps to 2 lines. */}
+        <p className="text-sm text-text-secondary leading-relaxed mb-6 min-h-[3.5rem]">
+          {tier.description ?? ''}
+        </p>
+
+        {/* Price — fixed row so the big numbers land on the same baseline
+            across every card regardless of description length. */}
+        <div className="mb-6 flex items-baseline gap-1 h-[3.5rem]">
           <span
-            className={`text-5xl font-extrabold tracking-tight ${
+            className={`text-5xl font-extrabold tracking-tight leading-none ${
               isEnterprise ? 'text-text' : 'text-primary'
             }`}
             style={{ fontFamily: 'var(--font-display)' }}
@@ -71,32 +73,37 @@ export function PricingCard({ tier, productSlug, unitLabel }) {
           )}
         </div>
 
-        {/* Quota line — subtle, single sentence */}
-        {quotaLine && (
-          <p className="text-sm text-text font-semibold mb-4 pb-4 border-b border-black/5">
-            {quotaLine}
-          </p>
-        )}
+        {/* Quota line — min-h reserves the row even when a tier has no
+            quota data, so the divider + features list start at the same Y
+            on every card. */}
+        <div className="min-h-[2.5rem] mb-4 pb-4 border-b border-black/5 flex items-start">
+          {quotaLine ? (
+            <p className="text-sm text-text font-semibold leading-snug">{quotaLine}</p>
+          ) : null}
+        </div>
 
-        {/* Features */}
+        {/* Features — flex-1 pushes the CTA to the bottom. */}
         <ul className="space-y-2.5 mb-8 flex-1">
           {tier.features?.map((f, fi) => {
             const isInheritance = f.toLowerCase().startsWith('everything in')
             return (
               <li
                 key={fi}
-                className={`flex items-start gap-2.5 text-sm ${
+                className={`flex items-start gap-2 text-sm ${
                   isInheritance
                     ? 'text-text font-semibold pb-2 mb-1 border-b border-black/5'
                     : 'text-text-secondary'
                 }`}
               >
                 {!isInheritance && (
-                  <span className="mt-0.5 shrink-0 flex h-4 w-4 items-center justify-center rounded-full bg-emerald-100">
-                    <Check size={10} strokeWidth={3} className="text-emerald-600" />
-                  </span>
+                  <Check
+                    size={16}
+                    strokeWidth={2.5}
+                    className="text-emerald-600 mt-0.5 shrink-0"
+                    aria-hidden="true"
+                  />
                 )}
-                <span className={isInheritance ? 'pt-0' : ''}>{f}</span>
+                <span>{f}</span>
               </li>
             )
           })}


### PR DESCRIPTION
## Summary

Two direct regressions from #83 you caught on the live site:

1. **Checkmarks looked emoji-like** — circle wrapper + heavy stroke made them read as stickers. Fixed: dropped the circle, checks are now plain lucide `Check` glyphs (emerald-600, stroke 2.5, size 16) sitting on the text baseline. Reads as type, not emoji.
2. **Tier cards misaligned** — tier names, prices, feature lists all sat at different Y coordinates across cards because internal sections had content-driven heights. Fixed: `min-h` on every section + `auto-rows-fr` on the grid parent. Now every card has identical row positions across Starter / Pro / Business / Enterprise.

## Files changed

- `components/pricing/PricingCard.jsx` — checkmark simplification + min-h on name/description/price/quota sections
- `app/products/[slug]/pricing/page.jsx` — `auto-rows-fr` on the tier grid

## Test plan

- [x] `npm run lint:colors` OK
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test:visual` 58/58 passing
- [ ] Reviewer: check `/products/messenger/pricing` in DevTools — inspect each tier card, verify `.text-xl` name spans + `.text-5xl` price spans sit at the same `offsetTop` across all four cards
- [ ] Reviewer: confirm checkmarks in feature lists now look like type (plain emerald check), no circle backgrounds
- [ ] Reviewer: verify Receptionist / Outreach / Space pricing pages have the same aligned layout

## Closes / references

- Closes #84
- Refs #83 (pricing redesign — this fixes the regressions it shipped)