### PR TITLE
feat(pricing): restore full tier grid on product page + upgrade compare-plan matrix

### DIFF
--- a/app/products/[slug]/page.jsx
+++ b/app/products/[slug]/page.jsx
@@ -283,25 +283,51 @@ export default async function ProductPage({ params }) {
               </Link>
             </AnimatedSection>
           ) : (
-            <div className="max-w-sm mx-auto">
+            <>
               {(() => {
-                // Teaser shows the highlighted (Most Popular) tier only. Full tier
-                // grid + compare-plan table + Essentials + Enterprise live on the
-                // dedicated pricing page, preventing redundant display.
-                const featuredTier =
-                  product.pricing.tiers.find((t) => t.highlighted) ??
-                  product.pricing.tiers[Math.floor(product.pricing.tiers.length / 2)]
+                // Build the same 4-tier grid as the dedicated pricing page —
+                // Starter / Pro / Business / Enterprise (Enterprise synthesized
+                // inline from pricing.enterprise data). Keeps the product page
+                // and the dedicated /pricing page visually consistent, which
+                // is the industry pattern (HubSpot / Dialpad / Zendesk / etc.).
+                const coreTiers = product.pricing.tiers
+                const ent = product.pricing.enterprise
+                const enterpriseTier = ent
+                  ? {
+                      slug: 'enterprise',
+                      name: 'Enterprise',
+                      price: 'Custom',
+                      period: '',
+                      description: ent.description,
+                      priceFrom: ent.priceFrom,
+                      features: ent.features ?? [],
+                    }
+                  : null
+                const gridTiers = enterpriseTier
+                  ? [...coreTiers, enterpriseTier]
+                  : coreTiers
+                const gridColsClass =
+                  gridTiers.length === 4
+                    ? 'lg:grid-cols-4'
+                    : 'lg:grid-cols-3'
                 return (
-                  <AnimatedSection>
-                    <PricingCard
-                      tier={featuredTier}
-                      productSlug={slug}
-                      unitLabel={product.pricing.unitLabel}
-                    />
-                  </AnimatedSection>
+                  <div
+                    className={`grid grid-cols-1 md:grid-cols-2 ${gridColsClass} auto-rows-fr gap-6 items-stretch`}
+                  >
+                    {gridTiers.map((tier, i) => (
+                      <AnimatedSection key={tier.slug ?? i} delay={i * 0.06}>
+                        <PricingCard
+                          tier={tier}
+                          productSlug={slug}
+                          unitLabel={product.pricing.unitLabel}
+                        />
+                      </AnimatedSection>
+                    ))}
+                  </div>
                 )
               })()}
-              <AnimatedSection delay={0.1}>
+
+              <AnimatedSection delay={0.3}>
                 <div className="text-center mt-10">
                   <Link
                     href={`/products/${slug}/pricing`}
@@ -312,7 +338,7 @@ export default async function ProductPage({ params }) {
                   </Link>
                 </div>
               </AnimatedSection>
-            </div>
+            </>
           )}
         </div>
       </section>

--- a/app/products/[slug]/pricing/page.jsx
+++ b/app/products/[slug]/pricing/page.jsx
@@ -215,9 +215,11 @@ export default async function ProductPricingPage({ params }) {
               </h2>
             </AnimatedSection>
             <AnimatedSection delay={0.1}>
-              <div className="rounded-2xl border border-primary-100 bg-white p-6 sm:p-8">
-                <FeatureComparison tiers={gridTiers} features={comparisonRows} />
-              </div>
+              <FeatureComparison
+                tiers={gridTiers}
+                features={comparisonRows}
+                productSlug={slug}
+              />
             </AnimatedSection>
           </div>
         </section>

--- a/components/pricing/FeatureComparison.jsx
+++ b/components/pricing/FeatureComparison.jsx
@@ -1,67 +1,212 @@
-import { Check, Minus } from 'lucide-react'
+'use client'
+
+import Link from 'next/link'
+import { Check, X, ArrowRight, Mail } from 'lucide-react'
 
 /**
- * Feature comparison table. Accepts tier data and a feature matrix.
- * Each row: { label: string, values: [true|false|string, ...] } (one per tier)
+ * Compare-plan matrix. Accepts tier data and a flat feature matrix now;
+ * optional categorized featureGroups prop reserved for future grouped
+ * rendering once per-product feature-group data is authored.
+ *
+ * Each feature row: { label: string, values: [true|false|string, ...] }
+ * values array length === tiers length, same order.
  */
-export function FeatureComparison({ tiers, features }) {
+export function FeatureComparison({ tiers, features, productSlug }) {
+  if (!tiers?.length || !features?.length) return null
+
+  const columnCount = tiers.length
+  const gridCols = `minmax(220px,1fr) repeat(${columnCount}, minmax(140px,1fr))`
+  const gridStyle = { gridTemplateColumns: gridCols }
+
   return (
-    <div className="overflow-x-auto">
-      <table className="w-full border-collapse">
-        <thead>
-          <tr className="border-b border-black/10">
-            <th className="text-left py-4 pr-4 text-sm font-semibold text-text-secondary uppercase tracking-wider">
-              Features
-            </th>
-            {tiers.map((tier) => (
-              <th
-                key={tier.slug}
-                className={`text-center py-4 px-4 ${tier.highlighted ? 'text-primary' : 'text-text'}`}
-              >
-                <div
-                  className="text-base font-bold"
-                  style={{ fontFamily: 'var(--font-display)' }}
-                >
-                  {tier.name}
-                </div>
-                <div className="text-xs text-text-secondary font-normal mt-1">
-                  {tier.price}
-                  {tier.period}
-                </div>
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {features.map((row, ri) => (
-            <tr
-              key={ri}
-              className="border-b border-black/5 hover:bg-[#F7F9FF]/50 transition-colors"
+    <>
+      {/* Desktop matrix */}
+      <div className="hidden md:block">
+        <div className="overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/[0.04]">
+          <ColumnHeaders tiers={tiers} gridStyle={gridStyle} />
+          <FeatureRows
+            tiers={tiers}
+            features={features}
+            gridStyle={gridStyle}
+          />
+          <BottomCtaRow
+            tiers={tiers}
+            productSlug={productSlug}
+            gridStyle={gridStyle}
+          />
+        </div>
+      </div>
+
+      {/* Mobile: horizontally scrollable, sticky feature label column */}
+      <div className="md:hidden -mx-4 px-4 overflow-x-auto">
+        <div className="min-w-[720px] overflow-hidden rounded-2xl bg-white shadow-sm ring-1 ring-black/[0.04]">
+          <ColumnHeaders tiers={tiers} gridStyle={gridStyle} compact />
+          <FeatureRows
+            tiers={tiers}
+            features={features}
+            gridStyle={gridStyle}
+            compact
+          />
+          <BottomCtaRow
+            tiers={tiers}
+            productSlug={productSlug}
+            gridStyle={gridStyle}
+            compact
+          />
+        </div>
+      </div>
+    </>
+  )
+}
+
+function ColumnHeaders({ tiers, gridStyle, compact = false }) {
+  return (
+    <div
+      className="grid border-b border-black/5"
+      style={gridStyle}
+    >
+      <div className={compact ? 'p-4' : 'p-5'} />
+      {tiers.map((tier) => (
+        <div
+          key={tier.slug}
+          className={`text-center ${compact ? 'px-3 py-4' : 'px-4 py-5'} ${
+            tier.highlighted ? 'bg-primary/[0.04]' : ''
+          }`}
+        >
+          <p
+            className={`font-semibold text-text ${compact ? 'text-xs' : 'text-sm'}`}
+            style={{ fontFamily: 'var(--font-display)' }}
+          >
+            {tier.name}
+          </p>
+          <p className={`mt-0.5 font-medium text-text-muted ${compact ? 'text-[11px]' : 'text-xs'}`}>
+            {tier.slug === 'enterprise'
+              ? 'Custom'
+              : `${tier.price}${tier.period ?? ''}`}
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function FeatureRows({ tiers, features, gridStyle, compact = false }) {
+  return (
+    <div>
+      {features.map((row, ri) => {
+        const isOdd = ri % 2 === 1
+        return (
+          <div
+            key={ri}
+            className={`grid ${isOdd ? 'bg-black/[0.015]' : ''}`}
+            style={gridStyle}
+          >
+            <div
+              className={`flex items-center ${compact ? 'px-4 py-3' : 'px-5 py-3.5'} ${
+                compact
+                  ? 'sticky left-0 bg-white/95 backdrop-blur-sm z-10'
+                  : ''
+              }`}
             >
-              <td className="py-3 pr-4 text-sm text-text font-medium">{row.label}</td>
-              {row.values.map((val, vi) => (
-                <td key={vi} className="text-center py-3 px-4">
-                  {val === true ? (
-                    <Check
-                      size={18}
-                      className="inline-block text-primary"
-                      strokeWidth={2.5}
-                    />
-                  ) : val === false ? (
-                    <Minus
-                      size={16}
-                      className="inline-block text-text-muted"
-                      strokeWidth={2}
-                    />
-                  ) : (
-                    <span className="text-sm text-text-secondary">{val}</span>
-                  )}
-                </td>
-              ))}
-            </tr>
-          ))}
-        </tbody>
-      </table>
+              <span className={`text-text-secondary ${compact ? 'text-xs' : 'text-sm'}`}>
+                {row.label}
+              </span>
+            </div>
+            {row.values.map((val, vi) => {
+              const tier = tiers[vi]
+              const cellBg = tier?.highlighted
+                ? isOdd
+                  ? 'bg-primary/[0.05]'
+                  : 'bg-primary/[0.04]'
+                : ''
+              return (
+                <div
+                  key={vi}
+                  className={`flex items-center justify-center ${
+                    compact ? 'px-3 py-3' : 'px-4 py-3.5'
+                  } ${cellBg}`}
+                >
+                  <FeatureValue value={val} />
+                </div>
+              )
+            })}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+function FeatureValue({ value }) {
+  if (typeof value === 'string') {
+    return (
+      <span className="text-sm font-medium text-text text-center">{value}</span>
+    )
+  }
+  if (value === true) {
+    return (
+      <span
+        className="flex h-5 w-5 items-center justify-center rounded-full bg-emerald-100"
+        aria-label="Included"
+      >
+        <Check size={12} strokeWidth={3} className="text-emerald-600" />
+      </span>
+    )
+  }
+  return (
+    <X
+      size={16}
+      strokeWidth={2}
+      className="text-red-300"
+      aria-label="Not included"
+    />
+  )
+}
+
+function BottomCtaRow({ tiers, productSlug, gridStyle, compact = false }) {
+  return (
+    <div
+      className="grid border-t border-black/5"
+      style={gridStyle}
+    >
+      <div className={compact ? 'p-4' : 'p-5'} />
+      {tiers.map((tier) => {
+        const tierSlug = tier.slug || tier.name?.toLowerCase()
+        const isEnterprise = tier.slug === 'enterprise'
+        const href = productSlug
+          ? `/contact?product=${productSlug}&tier=${tierSlug}`
+          : '/contact'
+        return (
+          <div
+            key={tier.slug}
+            className={`flex items-center justify-center ${compact ? 'px-3 py-4' : 'px-4 py-5'} ${
+              tier.highlighted ? 'bg-primary/[0.04]' : ''
+            }`}
+          >
+            {isEnterprise ? (
+              <Link
+                href={href}
+                className="inline-flex items-center gap-1.5 rounded-lg border border-black/10 bg-white px-3 py-2 text-xs font-semibold text-text no-underline hover:border-primary/40 hover:text-primary transition-colors"
+              >
+                <Mail size={12} strokeWidth={2} />
+                Contact Sales
+              </Link>
+            ) : (
+              <Link
+                href={href}
+                className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-semibold no-underline transition-colors ${
+                  tier.highlighted
+                    ? 'bg-navy text-white hover:bg-primary-700'
+                    : 'border border-black/10 bg-white text-text hover:border-primary/40 hover:text-primary'
+                }`}
+              >
+                Get Started
+                <ArrowRight size={12} strokeWidth={2} />
+              </Link>
+            )}
+          </div>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Two corrections after live review of #83 / #85:

### 1. Product page pricing section → back to full 4-tier grid

My previous single-tier teaser wasn't standard industry practice (HubSpot / Dialpad / Zendesk / RingCentral all show the full tier grid on the product page). Reverted to 4-card row (Starter / Pro / Business / Enterprise inline) with the "See full pricing — all tiers and compare plans →" link below. Now the product page and `/products/[slug]/pricing` show the same tier grid — redundancy IS the pattern for price transparency.

### 2. Compare-plan matrix upgraded to RecV aesthetic

`FeatureComparison.jsx` rewritten to match the reference you shared:

- **Green Check in emerald-100 circle** for included features
- **Red X (text-red-300, subtle)** for missing features
- **Pro column highlighted throughout** — column header, every row, bottom CTA row (`bg-primary/[0.04]` rising to `[0.05]` on odd rows)
- **Row alternation** on odd rows (`bg-black/[0.015]`)
- **String values** render as bold text for rows with numeric/textual values (reserved for future categorized data — empty for now)
- **Bottom CTA row** with Get Started / Contact Sales buttons per tier column, Pro tier gets the solid navy button
- **Desktop + mobile layouts** — mobile uses horizontal scroll with sticky feature-label column
- **Premium card surface** — `rounded-2xl bg-white shadow-sm ring-1 ring-black/[0.04]`, matching Phase A card language

### What's NOT in this PR (intentional)

**Categorized feature groups** (Capacity / Call Handling / Integrations / Support / Security / Analytics with string values like "200 min / 500 min / 800 min / Custom") require per-product feature-group data to be authored in `data/products.js`. Currently each product has a flat `tier.features` array. The component accepts string values and is ready to render grouped data when authored; the call site passes a flat boolean matrix derived from the existing feature lists.

Follow-up PR when you author the detailed per-product feature matrices. You mentioned wanting to approve feature detail later — this PR ships the visual shell, follow-up fills in the content.

## Files changed

- `components/pricing/FeatureComparison.jsx` — full rewrite (~200 lines)
- `app/products/[slug]/pricing/page.jsx` — pass `productSlug` to FeatureComparison, drop the old card wrapper (now handled inside FeatureComparison)
- `app/products/[slug]/page.jsx` — restore full 4-tier grid in the pricing section, Enterprise synthesized inline same as the dedicated pricing page

## Test plan

- [x] `npm run lint:colors` OK
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test:visual` 58/58 passing, baselines regenerated
- [ ] Reviewer: `/products/messenger` — confirm 4 tier cards in pricing section (Starter/Pro/Business/Enterprise), alignment still holds, CTA below grid links to `/products/messenger/pricing`
- [ ] Reviewer: `/products/messenger/pricing` compare-plan matrix — confirm green-circle checks, red-X for missing, Pro column subtly highlighted, alternating row bg, bottom CTA buttons per tier
- [ ] Reviewer: resize window to mobile — confirm matrix scrolls horizontally, feature labels stay sticky
- [ ] Reviewer: check other products (Receptionist / Outreach / Space) render consistently

## Closes / references

- Closes #86
- Refs #83 (pricing redesign) / #85 (alignment fix) — this corrects the single-tier teaser choice in #83
- User-shared RecV pricing source 2026-04-21 used as the visual reference