### PR TITLE
fix(bg): real brand Logo, visible grain, transparent sections, drop cheap divider

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -6,7 +6,6 @@ import { Stats } from '@/components/sections/Stats'
 import { Testimonials } from '@/components/sections/Testimonials'
 import { IntegrationStrip } from '@/components/sections/IntegrationStrip'
 import { CTASection } from '@/components/sections/CTASection'
-import { AtmosphericDivider } from '@/components/design'
 
 export const metadata = {
   title: 'JotilLabs - AI Voice, Chat & Automation Platform',
@@ -14,43 +13,27 @@ export const metadata = {
     'Never miss a customer again. JotilLabs AI voice agents, chatbots, and SMS automation handle your calls, chats, leads, and workflows 24/7.',
 }
 
-// Surface color references — keep in sync with app/globals.css @theme tokens.
-// Used by the AtmosphericDividers on this page to bleed between sections
-// where colors change (no divider needed when neighbors share a color).
-const BG = 'var(--color-bg)'
-const SUNKEN = 'var(--color-primary-50)'
-const NAVY = 'var(--color-navy)'
-
+/**
+ * Sections stack with transparent bgs so the fixed BrandBackground
+ * (mounted in app/layout.jsx) shows through consistently as visitors
+ * scroll. Glass cards inside each section blur whatever bg is behind
+ * them — which is now always BrandBackground, not a section-level
+ * opaque color.
+ *
+ * No AtmosphericDividers between sections: the bg is already unified,
+ * so section-to-section color transitions aren't needed. CTASection
+ * keeps its own internal dark gradient for the closer.
+ */
 export default function Home() {
   return (
     <>
       <Hero />
-      {/* Hero wash → flat bg (LogoCloud) — very subtle */}
-
       <LogoCloud />
-      {/* Flat bg → sunken cool (ProductShowcase) */}
-      <AtmosphericDivider from={BG} to={SUNKEN} height={80} />
-
       <ProductShowcase />
-      {/* Sunken → flat bg (HowItWorks) */}
-      <AtmosphericDivider from={SUNKEN} to={BG} height={80} />
-
       <HowItWorks />
-      {/* Flat bg → sunken cool (Stats) */}
-      <AtmosphericDivider from={BG} to={SUNKEN} height={80} />
-
       <Stats />
-      {/* Sunken → flat bg (Testimonials) */}
-      <AtmosphericDivider from={SUNKEN} to={BG} height={80} />
-
       <Testimonials />
-      {/* Testimonials and IntegrationStrip both flat bg — no divider */}
-
       <IntegrationStrip />
-      {/* Flat bg → navy CTASection — linear transition straight into dark,
-          no bright primary-blue "sunrise" flare before the navy. */}
-      <AtmosphericDivider from={BG} to={NAVY} height={100} />
-
       <CTASection />
     </>
   )

--- a/components/design/BrandBackground.jsx
+++ b/components/design/BrandBackground.jsx
@@ -1,30 +1,31 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
+import Logo from '@/components/ui/Logo'
 
 /**
  * Signature site background: asymmetric blue radial blob bottom-left,
- * grain masked to the blob area, optional logo watermark on the right.
+ * visible grain masked to the blob area, optional real-logo watermark
+ * on the right edge (homepage only).
  *
  * Variants:
- *   - "hero"  — homepage treatment: blob + grain + watermark + mouse parallax
- *   - "quiet" — other pages: blob + grain only, no watermark, no parallax
+ *   - "hero"  — homepage: blob + grain + real logo watermark + mouse parallax
+ *   - "quiet" — other pages: blob + grain at lower intensity, no watermark
  *
- * Implementation notes:
- *   - All CSS + SVG. No canvas, no per-frame JS work except parallax transforms
- *     when enabled.
- *   - Parallax gated on (pointer: fine) and prefers-reduced-motion: no-preference
- *     via matchMedia. Touch + reduced-motion users get static composition.
- *   - Fixed-positioned; passes through pointer events so nothing below it
- *     is click-blocked.
- *   - Watermark hidden below md breakpoint via CSS (no render cost on mobile).
+ * Notes:
+ *   - Uses the real brand <Logo> component for the watermark (not a simplified
+ *     mockup). Animate=false so the dots don't pulse distractingly behind
+ *     content.
+ *   - All CSS + SVG; no canvas, no per-frame JS at rest. Parallax loop
+ *     self-cancels when lerp is near target.
+ *   - Parallax gated on (pointer: fine) AND prefers-reduced-motion:
+ *     no-preference. Touch + reduced-motion users get static composition.
  */
 export function BrandBackground({ variant = 'quiet' }) {
   const blobRef = useRef(null)
   const watermarkRef = useRef(null)
   const grainRef = useRef(null)
 
-  // Mouse parallax — only on hero variant, only on fine pointer + no reduced motion
   useEffect(() => {
     if (variant !== 'hero') return
     if (typeof window === 'undefined') return
@@ -47,7 +48,6 @@ export function BrandBackground({ variant = 'quiet' }) {
 
     const update = () => {
       rafId = 0
-      // Smooth lerp toward mouse position — lighter than hard cursor tracking
       currentX += (mouseX - currentX) * 0.08
       currentY += (mouseY - currentY) * 0.08
 
@@ -66,7 +66,6 @@ export function BrandBackground({ variant = 'quiet' }) {
         watermarkRef.current.style.transform = `perspective(1100px) rotateX(${tiltX}deg) rotateY(${tiltY}deg)`
       }
 
-      // Continue lerp until we're near the target
       if (
         Math.abs(mouseX - currentX) > 0.002 ||
         Math.abs(mouseY - currentY) > 0.002
@@ -82,77 +81,68 @@ export function BrandBackground({ variant = 'quiet' }) {
     }
   }, [variant])
 
-  const blobOpacity = variant === 'hero' ? 0.85 : 0.5
+  // Hero variant: stronger blob + grain + watermark.
+  // Quiet variant: softer blob + softer grain, no watermark.
+  const blobOpacity = variant === 'hero' ? 0.95 : 0.55
+  const grainOpacity = variant === 'hero' ? 0.38 : 0.22
 
   return (
     <div
       aria-hidden="true"
       className="pointer-events-none fixed inset-0 z-0 overflow-hidden"
     >
-      {/* Blob — asymmetric radial gradient bottom-left. Uses brand primary.
-          Fixed position, fades up-and-right into page bg. */}
+      {/* Blob — asymmetric radial gradient bottom-left. Brand primary #3859a8. */}
       <div
         ref={blobRef}
         className="absolute inset-0 will-change-transform"
         style={{
           opacity: blobOpacity,
           background: `radial-gradient(ellipse 62% 68% at -8% 112%,
-            rgba(56, 89, 168, 0.45) 0%,
-            rgba(56, 89, 168, 0.30) 22%,
-            rgba(140, 155, 210, 0.18) 42%,
+            rgba(56, 89, 168, 0.55) 0%,
+            rgba(56, 89, 168, 0.38) 22%,
+            rgba(140, 155, 210, 0.22) 42%,
             rgba(200, 210, 232, 0.08) 58%,
             transparent 70%)`,
           transition: 'transform 0.6s cubic-bezier(0.22, 1, 0.36, 1)',
         }}
       />
 
-      {/* Grain — masked to the same blob shape so texture only shows where
-          there is color. SVG fractal noise inline-encoded; no network cost. */}
+      {/* Grain — high-frequency SVG noise masked to the same blob shape.
+          Multiply blend darkens where there's already color; invisible where
+          the blob fades to transparent. */}
       <div
         ref={grainRef}
         className="absolute inset-0 will-change-transform"
         style={{
-          opacity: 0.12,
+          opacity: grainOpacity,
           backgroundImage: `url("data:image/svg+xml;utf8,${encodeURIComponent(
-            `<svg viewBox='0 0 240 240' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.22 0 0 0 0 0.35 0 0 0 0 0.66 0 0 0 0.55 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>`
+            `<svg viewBox='0 0 260 260' xmlns='http://www.w3.org/2000/svg'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='1.15' numOctaves='3' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0.14 0 0 0 0 0.22 0 0 0 0 0.42 0 0 0 0.85 0'/></filter><rect width='100%' height='100%' filter='url(%23n)'/></svg>`
           )}")`,
-          // Mask grain to the blob's shape — ellipse bottom-left
-          WebkitMaskImage: `radial-gradient(ellipse 62% 68% at -8% 112%, black 0%, black 40%, transparent 70%)`,
-          maskImage: `radial-gradient(ellipse 62% 68% at -8% 112%, black 0%, black 40%, transparent 70%)`,
+          backgroundSize: '260px 260px',
+          WebkitMaskImage:
+            'radial-gradient(ellipse 62% 68% at -8% 112%, black 0%, black 35%, transparent 70%)',
+          maskImage:
+            'radial-gradient(ellipse 62% 68% at -8% 112%, black 0%, black 35%, transparent 70%)',
           mixBlendMode: 'multiply',
           transition: 'transform 0.6s cubic-bezier(0.22, 1, 0.36, 1)',
         }}
       />
 
-      {/* Watermark — logo hex on right edge, partially revealed.
-          Hero variant only. Hidden below md breakpoint. */}
+      {/* Logo watermark — real brand Logo, partially revealed on right edge.
+          Hero variant only. Hidden below md breakpoint. Uses the actual
+          Logo component (hex body + depth + 3 dots), not a simplified mockup. */}
       {variant === 'hero' && (
         <div
           ref={watermarkRef}
-          className="absolute inset-0 hidden md:block"
+          className="absolute inset-y-0 hidden md:flex items-center will-change-transform"
           style={{
+            right: '-18%',
+            opacity: 0.07,
             transition: 'transform 0.6s cubic-bezier(0.22, 1, 0.36, 1)',
             transformStyle: 'preserve-3d',
           }}
         >
-          <svg
-            viewBox="0 0 116 124"
-            className="absolute top-1/2 -translate-y-1/2 right-[-18%] h-[90vh] w-auto opacity-[0.045]"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <polygon
-              points="29,28  75,28  98,68  75,108  29,108  6,68"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="8"
-              strokeLinejoin="round"
-              className="text-primary"
-            />
-            <polygon points="52,36 80,52 52,68 24,52" fill="currentColor" className="text-primary-300" />
-            <polygon points="24,52 52,68 52,100 24,84" fill="currentColor" className="text-navy" />
-            <polygon points="80,52 52,68 52,100 80,84" fill="currentColor" className="text-primary" />
-          </svg>
+          <Logo size={800} tone="brand" animate={false} />
         </div>
       )}
     </div>

--- a/components/sections/Hero.jsx
+++ b/components/sections/Hero.jsx
@@ -91,7 +91,7 @@ export function Hero() {
   useEffect(() => setMounted(true), [])
 
   return (
-    <section className="bg-brand-wash-mark relative min-h-screen flex items-center overflow-hidden pt-20">
+    <section className="relative min-h-screen flex items-center overflow-hidden pt-20">
       {/* Background gradient mesh */}
       <div className="pointer-events-none absolute inset-0" aria-hidden="true">
         {/* Soft grid pattern */}
@@ -211,8 +211,7 @@ export function Hero() {
         </div>
       </div>
 
-      {/* Bottom fade */}
-      <div className="absolute bottom-0 left-0 right-0 h-24 pointer-events-none" style={{ background: 'linear-gradient(to bottom, transparent, var(--color-bg))' }} />
+      {/* Bottom fade removed — BrandBackground handles the transition now */}
     </section>
   )
 }

--- a/components/sections/ProductShowcase.jsx
+++ b/components/sections/ProductShowcase.jsx
@@ -51,7 +51,7 @@ const CAPABILITIES = [
 
 export function ProductShowcase() {
   return (
-    <section className="surface-sunken py-24">
+    <section className="py-24">
       <div className="max-w-7xl mx-auto px-6">
 
         {/* Heading */}

--- a/components/sections/Stats.jsx
+++ b/components/sections/Stats.jsx
@@ -42,7 +42,7 @@ const STATS = [
 
 export function Stats() {
   return (
-    <section className="surface-sunken py-20">
+    <section className="py-20">
       <div className="max-w-7xl mx-auto px-6">
 
         {/* Optional section label */}


### PR DESCRIPTION
## Summary

Fix for four regressions that landed in production via PR #89. **Production currently has the broken version; this PR replaces it.**

| Bug | Fix |
|---|---|
| Fake simplified-hexagon watermark | Imports the real `<Logo>` component from `components/ui/Logo.jsx` at `size=800` with `animate=false`. Hex body + depth layer + 3 dots. |
| Grain invisible at 12% opacity | Hero variant bumped to 38%, quiet variant to 22%. `baseFrequency` raised to 1.15 / 3 octaves, color matrix deepened. |
| Blob flickers on scroll | Homepage sections had opaque `surface-sunken` / `bg-brand-wash-mark` classes painting over the fixed BrandBackground. Stripped from `Stats`, `ProductShowcase`, `Hero` + removed Hero's bottom fade. Sections now transparent, BrandBackground shows through consistently. |
| Cheap linear gradient before dark CTA | Removed ALL `AtmosphericDivider` uses from `app/page.jsx`. Sections stack directly. CTASection's own inline navy gradient handles the dark closer. |

**CTASection + Footer untouched** — you explicitly said keep those.

## Meta-error I made

My original fix commit was pushed AFTER PR #89 was already merged — so it landed on a dead branch and never made it to main. Production shipped with the bug. This PR is a cherry-pick of that fix onto a fresh branch off main. Won't happen again — I'll check PR state before pushing follow-up commits.

## Files changed

- `components/design/BrandBackground.jsx` — real Logo + visible grain
- `components/sections/Hero.jsx` — drop `bg-brand-wash-mark` class + bottom-fade div
- `components/sections/Stats.jsx` — drop `surface-sunken` class
- `components/sections/ProductShowcase.jsx` — drop `surface-sunken` class
- `app/page.jsx` — drop all AtmosphericDividers

## Test plan

- [x] `npm run lint:colors` OK
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test:visual` 58/58 with regenerated baselines
- [ ] Reviewer: `/` on Vercel preview — confirm real brand logo visible as watermark (hex + depth + dots), not a plain hexagon
- [ ] Reviewer: grain is visibly textured in the blob area, not a ghost
- [ ] Reviewer: scroll the homepage — blob should NOT appear/disappear as sections pass; should stay consistently visible under transparent sections
- [ ] Reviewer: no gradient bridge between IntegrationStrip and CTASection — just direct transition to the navy closer
- [ ] Reviewer: CTASection "Stop losing customers" + footer look identical to before

## Closes / references

- Closes #90
- Refs #89 (which shipped the regressions this fixes)
- Refs user direct feedback 2026-04-22