### PR TITLE
Polish showcase: bigger phones, no tilt, subtler background, messenger rewrite

### DIFF
--- a/components/design/BrandBackground.jsx
+++ b/components/design/BrandBackground.jsx
@@ -73,7 +73,7 @@ export function BrandBackground({ variant = 'quiet' }) {
           background:
             'radial-gradient(circle at 30% 30%, rgba(138, 107, 255, 0.35), transparent 60%), radial-gradient(circle at 70% 60%, rgba(255, 122, 182, 0.25), transparent 55%)',
           filter: 'blur(60px)',
-          opacity: isHero ? 1 : 0.72,
+          opacity: (isHero ? 1 : 0.72) * 0.4,
           willChange: isHero ? 'transform' : 'auto',
         }}
       />
@@ -90,7 +90,7 @@ export function BrandBackground({ variant = 'quiet' }) {
           background:
             'radial-gradient(circle at 60% 40%, rgba(47, 91, 255, 0.28), transparent 60%), radial-gradient(circle at 30% 70%, rgba(255, 201, 163, 0.3), transparent 55%)',
           filter: 'blur(70px)',
-          opacity: isHero ? 1 : 0.72,
+          opacity: (isHero ? 1 : 0.72) * 0.4,
           willChange: isHero ? 'transform' : 'auto',
         }}
       />
@@ -102,7 +102,7 @@ export function BrandBackground({ variant = 'quiet' }) {
           inset: 0,
           pointerEvents: 'none',
           zIndex: 1,
-          opacity: 0.35,
+          opacity: 0.35 * 0.4,
           mixBlendMode: 'overlay',
           backgroundImage: `url("${NOISE_SVG}")`,
           backgroundSize: '200px 200px',

--- a/components/sections/showcase/SlideDevice.jsx
+++ b/components/sections/showcase/SlideDevice.jsx
@@ -26,9 +26,9 @@ const DEVICES = {
 }
 
 const TILT = {
-  phone: 'rotateY(-8deg) rotateX(4deg)',
-  laptop: 'rotateY(-6deg) rotateX(3deg)',
-  monitor: 'rotateY(-5deg) rotateX(2deg)',
+  phone: 'none',
+  laptop: 'none',
+  monitor: 'none',
 }
 
 export function SlideDevice({ slug, deviceType, isActive }) {
@@ -52,7 +52,7 @@ export function SlideDevice({ slug, deviceType, isActive }) {
 
   return (
     <div
-      className="relative flex justify-center items-center scale-[0.85] md:scale-100 origin-center"
+      className="relative flex justify-center items-center scale-[0.72] md:scale-100 origin-center"
       style={{
         perspective: '1200px',
         perspectiveOrigin: '50% 50%',

--- a/components/sections/showcase/cards/cardData.js
+++ b/components/sections/showcase/cards/cardData.js
@@ -1,4 +1,4 @@
-import { Calendar, MessageSquare, UserPlus, MessageCircle, Users, UserCheck, Mail, Phone, BarChart3, Brain, Inbox, Camera, Route, Sparkles } from 'lucide-react'
+import { Calendar, MessageSquare, UserPlus, Bell, Ticket, UserCheck, Mail, Phone, BarChart3, Brain, Inbox, Camera, Route, Sparkles } from 'lucide-react'
 
 export const FLOATING_CARDS = {
   receptionist: [
@@ -7,9 +7,9 @@ export const FLOATING_CARDS = {
     { id: 'crm', icon: UserPlus, label: 'Sarah Mitchell', sublabel: 'Added to CRM', top: '80px', left: '-55px', rotate: '-5deg', depth: '-60px' },
   ],
   messenger: [
-    { id: 'whatsapp', icon: MessageCircle, label: 'New message', sublabel: 'WhatsApp', top: '-30px', right: '-60px', rotate: '4deg', depth: '-50px' },
-    { id: 'teams', icon: Users, label: 'Channel synced', sublabel: 'Teams', bottom: '60px', right: '-65px', rotate: '-3deg', depth: '-30px' },
-    { id: 'handoff', icon: UserCheck, label: 'Escalated', sublabel: 'Human agent', top: '80px', left: '-55px', rotate: '-5deg', depth: '-60px' },
+    { id: 'calendar', icon: Calendar, label: 'Thu 10:00 AM', sublabel: 'Booked', top: '-30px', right: '-60px', rotate: '4deg', depth: '-50px' },
+    { id: 'reminder', icon: Bell, label: 'Reminder set', sublabel: 'SMS 9:00 AM', bottom: '60px', right: '-65px', rotate: '-3deg', depth: '-30px' },
+    { id: 'ticket', icon: Ticket, label: 'Ticket #4821', sublabel: 'CRM', top: '80px', left: '-55px', rotate: '-5deg', depth: '-60px' },
   ],
   outreach: [
     { id: 'email', icon: Mail, label: 'Drip sent', sublabel: 'Email sequence', top: '-30px', right: '-60px', rotate: '4deg', depth: '-50px' },

--- a/components/sections/showcase/devices/PhoneMockup.jsx
+++ b/components/sections/showcase/devices/PhoneMockup.jsx
@@ -6,7 +6,7 @@ export function PhoneMockup({ children, vibrate = false, glass = false }) {
         <div className="absolute left-[-2.5px] top-[124px] w-[3px] h-[32px] rounded-l-sm" style={{ background: 'linear-gradient(180deg, #3a3a40, #2a2a30)' }} />
         <div className="absolute left-[-2.5px] top-[164px] w-[3px] h-[32px] rounded-l-sm" style={{ background: 'linear-gradient(180deg, #3a3a40, #2a2a30)' }} />
         <div className="absolute right-[-2.5px] top-[130px] w-[3px] h-[40px] rounded-r-sm" style={{ background: 'linear-gradient(180deg, #3a3a40, #2a2a30)' }} />
-        <div className={`w-[280px] h-[580px] rounded-[46px] p-[10px] relative ${vibrate ? 'animate-phone-vibrate' : ''}`}
+        <div className={`w-[320px] h-[660px] rounded-[46px] p-[10px] relative ${vibrate ? 'animate-phone-vibrate' : ''}`}
           style={{
             background: 'linear-gradient(160deg, #2c2c30 0%, #1c1c20 40%, #0e0e12 100%)',
             boxShadow: [
@@ -39,7 +39,7 @@ export function PhoneMockup({ children, vibrate = false, glass = false }) {
       <div className="absolute right-[-2px] top-[130px] w-[2.5px] h-[40px] rounded-r-sm" style={{ background: 'linear-gradient(180deg, #d8d8dc, #c0c0c4)' }} />
 
       <div
-        className={`w-[280px] h-[580px] rounded-[46px] p-[10px] relative ${vibrate ? 'animate-phone-vibrate' : ''}`}
+        className={`w-[320px] h-[660px] rounded-[46px] p-[10px] relative ${vibrate ? 'animate-phone-vibrate' : ''}`}
         style={{
           background: 'linear-gradient(160deg, rgba(255,255,255,0.85) 0%, rgba(240,240,245,0.7) 30%, rgba(220,220,230,0.5) 70%, rgba(255,255,255,0.6) 100%)',
           backdropFilter: 'blur(20px) saturate(1.2)',

--- a/components/sections/showcase/screens/MessengerScreen.jsx
+++ b/components/sections/showcase/screens/MessengerScreen.jsx
@@ -2,39 +2,204 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Send } from 'lucide-react'
+import { Send, Calendar, Bell, Ticket, Sparkles } from 'lucide-react'
+import Logo from '@/components/ui/Logo'
 
-const channels = ['Web', 'SMS', 'WhatsApp', 'Teams']
-
-const MESSAGES = [
-  { role: 'user', text: 'Do you offer same-day service?' },
-  { role: 'ai', text: 'Yes! I have 2:30 PM and 4:00 PM today.' },
-  { role: 'user', text: '2:30 works. Book it!' },
-  { role: 'ai', text: "Booked! I'll send confirmation to WhatsApp." },
+const CHANNELS = [
+  { id: 'sms', label: 'SMS' },
+  { id: 'web', label: 'Web' },
+  { id: 'whatsapp', label: 'WhatsApp' },
+  { id: 'teams', label: 'Teams' },
 ]
 
-const LOOP_DURATION = 10000
+const SCRIPT = [
+  { type: 'msg', role: 'user', text: 'Hey, do you have any openings this week?' },
+  { type: 'msg', role: 'ai', text: 'Checking your calendar now...' },
+  { type: 'msg', role: 'ai', text: 'I have Thursday at 10 AM and Friday at 3 PM. Which works?' },
+  { type: 'msg', role: 'user', text: 'Thursday at 10, please.' },
+  { type: 'action', id: 'calendar', icon: Calendar, label: 'Appointment booked', sublabel: 'Thu, 10:00 AM' },
+  { type: 'channel', to: 1 },
+  { type: 'msg', role: 'user', text: "What's on the lunch menu today?" },
+  { type: 'msg', role: 'ai', text: "Today's specials: Grilled Salmon, Pasta Primavera, and Thai Curry Bowl." },
+  { type: 'msg', role: 'user', text: 'Can you remind me about my appointment tomorrow?' },
+  { type: 'action', id: 'reminder', icon: Bell, label: 'Reminder set', sublabel: 'SMS at 9:00 AM' },
+  { type: 'channel', to: 2 },
+  { type: 'msg', role: 'user', text: 'I need to reschedule my Friday meeting.' },
+  { type: 'msg', role: 'ai', text: 'No problem. Monday 2 PM or Tuesday 11 AM available. Preference?' },
+  { type: 'msg', role: 'user', text: 'Tuesday 11 works.' },
+  { type: 'action', id: 'reschedule', icon: Calendar, label: 'Rescheduled', sublabel: 'Tue, 11:00 AM' },
+  { type: 'channel', to: 3 },
+  { type: 'msg', role: 'user', text: 'Can you create a support ticket for the billing issue?' },
+  { type: 'msg', role: 'ai', text: "I'll create that right away with all the details from our conversation." },
+  { type: 'action', id: 'ticket', icon: Ticket, label: 'Ticket created', sublabel: 'Added to CRM' },
+  { type: 'msg', role: 'ai', text: 'Done! Ticket #4821 is assigned to your account manager.' },
+]
 
-function JAvatar({ size = 18 }) {
+const LOOP_DURATION = 38000
+
+function BlingAction({ action }) {
+  const Icon = action.icon
   return (
-    <div
-      className="rounded-full flex items-center justify-center text-white font-bold shrink-0"
-      style={{ width: size, height: size, background: 'linear-gradient(135deg, #3859a8, #2a4688)', fontSize: size * 0.5 }}
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      className="flex flex-col items-center py-2 my-1"
     >
-      J
+      <div className="relative">
+        {[0, 1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="absolute"
+            style={{
+              width: 6, height: 6,
+              top: '50%', left: '50%',
+              marginTop: [-14, -14, 8, 8][i],
+              marginLeft: [-14, 8, -14, 8][i],
+              animation: `bling-sparkle 0.8s ease-out ${i * 0.1}s`,
+              animationFillMode: 'forwards',
+              opacity: 0,
+            }}
+          >
+            <Sparkles size={6} className="text-amber-400" />
+          </div>
+        ))}
+        <div
+          className="w-9 h-9 rounded-xl flex items-center justify-center"
+          style={{
+            background: 'linear-gradient(135deg, rgba(56,89,168,0.12), rgba(56,89,168,0.06))',
+            animation: 'bling-in 0.5s ease-out',
+          }}
+        >
+          <Icon size={16} strokeWidth={1.5} style={{ color: '#3859a8' }} />
+        </div>
+      </div>
+      <motion.div
+        initial={{ opacity: 0, y: 4 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.3, duration: 0.2 }}
+        className="flex items-center gap-1 mt-1.5"
+      >
+        <div className="w-3 h-3 rounded-full bg-green-500/15 flex items-center justify-center">
+          <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
+        </div>
+        <span className="text-[9px] font-semibold" style={{ color: '#3859a8' }}>{action.label}</span>
+        <span className="text-[8px] text-gray-400">{action.sublabel}</span>
+      </motion.div>
+    </motion.div>
+  )
+}
+
+function TypingOrb() {
+  return (
+    <div className="flex justify-start mb-1.5">
+      <div className="flex items-center gap-1.5">
+        <div
+          className="w-7 h-7 rounded-full flex items-center justify-center shrink-0"
+          style={{
+            background: 'linear-gradient(135deg, #4a6fc2, #3859a8, #2a4688)',
+            animation: 'orb-pulse 1.2s ease-in-out infinite',
+          }}
+        >
+          <Logo size={12} tone="on-dark" animate={false} />
+        </div>
+        <div className="flex items-center gap-[2px] px-2 py-1.5 rounded-xl rounded-bl-sm bg-[#f1f3f5]">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              className="w-[2.5px] rounded-full"
+              style={{
+                height: 12,
+                backgroundColor: '#3859a8',
+                animation: `wave-bar 0.7s ease-in-out ${i * 0.08}s infinite`,
+              }}
+            />
+          ))}
+        </div>
+      </div>
     </div>
   )
 }
 
+function ChatBubble({ msg }) {
+  const isUser = msg.role === 'user'
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: 'easeOut' }}
+      className={`flex mb-1.5 ${isUser ? 'justify-end' : 'items-end gap-1.5'}`}
+    >
+      {!isUser && (
+        <div
+          className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
+          style={{ background: 'linear-gradient(135deg, #4a6fc2, #3859a8)' }}
+        >
+          <Logo size={9} tone="on-dark" animate={false} />
+        </div>
+      )}
+      <div
+        className={`max-w-[78%] px-2.5 py-1.5 text-[10px] leading-[1.4] ${
+          isUser ? 'rounded-xl rounded-br-sm text-white' : 'rounded-xl rounded-bl-sm text-gray-900'
+        }`}
+        style={{ backgroundColor: isUser ? '#3859a8' : '#f1f3f5' }}
+      >
+        {msg.text}
+      </div>
+    </motion.div>
+  )
+}
+
+function ChannelTab({ channel, isActive, offset }) {
+  return (
+    <motion.div
+      className="relative px-3 pb-1.5 text-center cursor-default"
+      animate={{
+        y: isActive ? 0 : 2,
+        scale: isActive ? 1 : 0.95,
+        opacity: isActive ? 1 : 0.5,
+      }}
+      transition={{ duration: 0.4, ease: 'easeOut' }}
+    >
+      <span className="text-[9px] font-medium" style={{ color: isActive ? '#3859a8' : '#999' }}>
+        {channel.label}
+      </span>
+      <AnimatePresence>
+        {isActive && (
+          <motion.span
+            layoutId="channel-underline"
+            className="absolute bottom-0 left-1/4 right-1/4 h-[2px] rounded-full"
+            style={{ backgroundColor: '#3859a8' }}
+            initial={{ scaleX: 0 }}
+            animate={{ scaleX: 1 }}
+            exit={{ scaleX: 0 }}
+            transition={{ duration: 0.3 }}
+          />
+        )}
+      </AnimatePresence>
+    </motion.div>
+  )
+}
+
 export function MessengerScreen({ isActive, onAction }) {
-  const [visibleMessages, setVisibleMessages] = useState(0)
-  const [showWhatsApp, setShowWhatsApp] = useState(false)
+  const [items, setItems] = useState([])
+  const [activeChannel, setActiveChannel] = useState(0)
+  const [isTyping, setIsTyping] = useState(false)
+  const [blingAction, setBlingAction] = useState(null)
+  const scrollRef = useRef(null)
   const loopRef = useRef(null)
 
   useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [items, isTyping, blingAction])
+
+  useEffect(() => {
     if (!isActive) {
-      setVisibleMessages(0)
-      setShowWhatsApp(false)
+      setItems([])
+      setActiveChannel(0)
+      setIsTyping(false)
+      setBlingAction(null)
       if (loopRef.current) loopRef.current.forEach(clearTimeout)
       return
     }
@@ -43,25 +208,58 @@ export function MessengerScreen({ isActive, onAction }) {
     const schedule = (fn, ms) => { const id = setTimeout(fn, ms); timers.push(id); return id }
 
     const runLoop = () => {
-      setVisibleMessages(0)
-      setShowWhatsApp(false)
+      setItems([])
+      setActiveChannel(0)
+      setIsTyping(false)
+      setBlingAction(null)
 
-      schedule(() => setVisibleMessages(1), 800)
-      schedule(() => setVisibleMessages(2), 2000)
-      schedule(() => setVisibleMessages(3), 3200)
+      let t = 600
+      const typeDur = 900
+      const gap = 350
 
-      schedule(() => {
-        setShowWhatsApp(true)
-        if (onAction) onAction('whatsapp')
-      }, 4000)
-      schedule(() => setShowWhatsApp(false), 5500)
+      SCRIPT.forEach((step) => {
+        if (step.type === 'msg') {
+          if (step.role === 'ai') {
+            schedule(() => setIsTyping(true), t)
+            t += typeDur
+            const msg = step
+            schedule(() => {
+              setIsTyping(false)
+              setItems((prev) => [...prev, msg])
+            }, t)
+            t += gap
+          } else {
+            const msg = step
+            schedule(() => setItems((prev) => [...prev, msg]), t)
+            t += gap + 300
+          }
+        } else if (step.type === 'action') {
+          t += 200
+          const action = step
+          schedule(() => {
+            setBlingAction(action)
+            if (onAction) onAction(action.id)
+          }, t)
+          t += 1000
+          schedule(() => {
+            setBlingAction(null)
+            setItems((prev) => [...prev, action])
+          }, t)
+          t += 300
+        } else if (step.type === 'channel') {
+          const ch = step.to
+          t += 400
+          schedule(() => {
+            setActiveChannel(ch)
+            setItems([])
+            setIsTyping(false)
+            setBlingAction(null)
+          }, t)
+          t += 800
+        }
+      })
 
-      schedule(() => setVisibleMessages(4), 5000)
-
-      schedule(() => { if (onAction) onAction('teams') }, 6500)
-      schedule(() => { if (onAction) onAction('handoff') }, 7500)
-
-      schedule(runLoop, LOOP_DURATION)
+      schedule(runLoop, Math.max(t + 2000, LOOP_DURATION))
     }
 
     runLoop()
@@ -71,35 +269,23 @@ export function MessengerScreen({ isActive, onAction }) {
 
   return (
     <div className="w-full h-full flex flex-col bg-white text-[11px] relative overflow-hidden">
-      {/* WhatsApp banner */}
-      <AnimatePresence>
-        {showWhatsApp && (
-          <motion.div
-            initial={{ y: -40 }}
-            animate={{ y: 0 }}
-            exit={{ y: -40 }}
-            transition={{ duration: 0.3 }}
-            className="absolute top-0 left-0 right-0 z-20 bg-[#25d366] text-white px-3 py-2 flex items-center gap-2"
-          >
-            <span className="text-[10px] font-semibold">WhatsApp</span>
-            <span className="text-[10px]">New message from a customer</span>
-          </motion.div>
-        )}
-      </AnimatePresence>
-
       {/* Channel tabs */}
-      <div className="pt-8 px-2 flex border-b border-gray-100 shrink-0">
-        {channels.map((ch, i) => (
-          <button key={ch} className="flex-1 pb-1.5 text-center text-[9px] font-medium relative" style={{ color: i === 0 ? '#3859a8' : '#999' }}>
-            {ch}
-            {i === 0 && <span className="absolute bottom-0 left-1/4 right-1/4 h-[2px] rounded-full" style={{ backgroundColor: '#3859a8' }} />}
-          </button>
+      <div className="pt-8 px-1 flex border-b border-gray-100 shrink-0">
+        {CHANNELS.map((ch, i) => (
+          <div key={ch.id} className="flex-1">
+            <ChannelTab channel={ch} isActive={activeChannel === i} offset={i} />
+          </div>
         ))}
       </div>
 
       {/* Chat header */}
       <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-50 shrink-0">
-        <JAvatar size={24} />
+        <div
+          className="w-6 h-6 rounded-full flex items-center justify-center shrink-0"
+          style={{ background: 'linear-gradient(135deg, #4a6fc2, #3859a8)' }}
+        >
+          <Logo size={11} tone="on-dark" animate={false} />
+        </div>
         <div>
           <p className="text-[11px] font-semibold text-gray-900">JotilLabs AI</p>
           <p className="text-[9px] text-green-600 flex items-center gap-1">
@@ -110,35 +296,83 @@ export function MessengerScreen({ isActive, onAction }) {
       </div>
 
       {/* Messages */}
-      <div className="flex-1 px-3 py-2 overflow-hidden space-y-2">
-        <AnimatePresence>
-          {MESSAGES.slice(0, visibleMessages).map((msg, i) => {
-            const isUser = msg.role === 'user'
-            return (
-              <motion.div
-                key={i}
-                initial={{ opacity: 0, y: 6 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 0.25 }}
-                className={`flex ${isUser ? 'justify-end' : 'items-end gap-1.5'}`}
-              >
-                {!isUser && <JAvatar size={16} />}
-                <div
-                  className={`max-w-[75%] px-2.5 py-1.5 text-[10.5px] leading-[1.4] ${
-                    isUser ? 'rounded-xl rounded-br-sm text-white' : 'rounded-xl rounded-bl-sm text-gray-900'
-                  }`}
-                  style={{ backgroundColor: isUser ? '#3859a8' : '#f1f3f5' }}
+      <div ref={scrollRef} className="flex-1 px-2.5 py-1.5 overflow-hidden">
+        <AnimatePresence mode="popLayout">
+          {items.map((item, i) => {
+            if (item.type === 'msg') {
+              return <ChatBubble key={`msg-${activeChannel}-${i}`} msg={item} />
+            }
+            if (item.type === 'action') {
+              return (
+                <motion.div
+                  key={`action-${activeChannel}-${item.id}`}
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
                 >
-                  {msg.text}
-                </div>
-              </motion.div>
-            )
+                  <BlingAction action={item} />
+                </motion.div>
+              )
+            }
+            return null
           })}
+
+          {isTyping && (
+            <motion.div
+              key={`typing-${activeChannel}-${items.length}`}
+              initial={{ opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.8 }}
+              transition={{ duration: 0.2 }}
+            >
+              <TypingOrb />
+            </motion.div>
+          )}
+
+          {blingAction && (
+            <motion.div
+              key={`bling-${activeChannel}-${blingAction.id}`}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+            >
+              <BlingAction action={blingAction} />
+            </motion.div>
+          )}
         </AnimatePresence>
       </div>
 
-      {/* Input bar */}
-      <div className="px-3 py-2 border-t border-gray-100 flex items-center gap-2 shrink-0">
+      {/* Bottom orb + input */}
+      <div className="shrink-0 px-3 py-2 border-t border-gray-100 flex items-center gap-2">
+        <div className="relative">
+          {isTyping && [0, 1].map((i) => (
+            <div
+              key={i}
+              className="absolute rounded-full"
+              style={{
+                width: 28, height: 28,
+                top: '50%', left: '50%',
+                marginTop: -14, marginLeft: -14,
+                border: '1px solid rgba(56,89,168,0.12)',
+                animation: `ring-expand 1.4s ease-out ${i * 0.35}s infinite`,
+              }}
+            />
+          ))}
+          <div
+            className="w-7 h-7 rounded-full flex items-center justify-center"
+            style={{
+              background: isTyping
+                ? 'linear-gradient(135deg, #22D3EE, #3859a8, #6366F1)'
+                : 'linear-gradient(135deg, #4a6fc2, #3859a8)',
+              boxShadow: isTyping
+                ? '0 0 12px rgba(34,211,238,0.4), 0 0 20px rgba(56,89,168,0.2)'
+                : '0 2px 6px rgba(56,89,168,0.2)',
+              animation: isTyping ? 'orb-pulse 1s ease-in-out infinite' : 'none',
+              transition: 'background 0.4s, box-shadow 0.4s',
+            }}
+          >
+            <Logo size={11} tone="on-dark" animate={false} />
+          </div>
+        </div>
         <div className="flex-1 bg-gray-50 rounded-full px-3 py-1.5 text-[10px] text-gray-400">Type a message...</div>
         <div className="w-7 h-7 rounded-full flex items-center justify-center shrink-0" style={{ backgroundColor: '#3859a8' }}>
           <Send className="w-3.5 h-3.5 text-white" strokeWidth={1.5} />


### PR DESCRIPTION
## Summary
- Remove 3D tilt effect from all device mockups (was not rendering well)
- Increase phone size from 280x580 to 320x660 with adjusted mobile scale
- Reduce BrandBackground atmosphere intensity to 40% (user-tested via /compare page)
- Rewrite MessengerScreen: JotilLabs logo replaces J avatars, typing orb animation, extended conversation across SMS/Web/WhatsApp/Teams with calendar booking, menu check, reminders, rescheduling, CRM ticket creation, bling action animations, animated channel tab switching

## Test plan
- [ ] Verify devices render without tilt, straight-on
- [ ] Verify phone mockup is visibly larger than before
- [ ] Verify background is subtler (40% of original intensity)
- [ ] Verify MessengerScreen cycles through all 4 channel tabs
- [ ] Verify typing orb animates when AI is responding
- [ ] Verify bling actions fire for calendar, reminder, ticket
- [ ] Test responsive layout on mobile viewport (phone should scale down cleanly)
- [ ] Hard refresh to avoid stale webpack cache (Cmd+Shift+R)