### PR TITLE
feat(messenger): stacked card deck with scroll-driven channel switching

### DIFF
--- a/components/sections/ScrollProductShowcase.jsx
+++ b/components/sections/ScrollProductShowcase.jsx
@@ -11,8 +11,12 @@ import { AnimatedSection } from '@/components/ui/AnimatedSection'
 
 gsap.registerPlugin(useGSAP, ScrollTrigger)
 
-const SCROLL_PER_PRODUCT = 1200
-const TOTAL_SCROLL = PRODUCT_SLIDES.length * SCROLL_PER_PRODUCT
+const MESSENGER_INDEX = 1
+const MESSENGER_CHANNELS = 4
+const BASE_SCROLL = 1200
+const TOTAL_SCROLL = PRODUCT_SLIDES.reduce((sum, _, i) =>
+  sum + (i === MESSENGER_INDEX ? BASE_SCROLL * MESSENGER_CHANNELS : BASE_SCROLL), 0
+)
 
 function ProgressDots({ activeIndex, total }) {
   return (
@@ -60,6 +64,7 @@ export function ScrollProductShowcase() {
   const containerRef = useRef(null)
   const [activeIndex, setActiveIndex] = useState(0)
   const [isMobile, setIsMobile] = useState(false)
+  const messengerProgressRef = useRef(0)
 
   useGSAP(() => {
     const container = containerRef.current
@@ -108,8 +113,27 @@ export function ScrollProductShowcase() {
           }
         }
 
-        tl.addLabel(`hold-${i}`)
-        tl.to({}, { duration: 0.4 })
+        if (i === MESSENGER_INDEX) {
+          const holdDur = 0.4 * MESSENGER_CHANNELS
+          const proxy = { progress: 0 }
+
+          tl.addLabel(`hold-${i}`)
+          for (let ch = 0; ch < MESSENGER_CHANNELS; ch++) {
+            tl.addLabel(`channel-${ch}`, `hold-${i}+=${(ch / MESSENGER_CHANNELS) * holdDur}`)
+          }
+
+          tl.to(proxy, {
+            progress: 1,
+            duration: holdDur,
+            ease: 'none',
+            onUpdate: () => {
+              messengerProgressRef.current = proxy.progress
+            },
+          })
+        } else {
+          tl.addLabel(`hold-${i}`)
+          tl.to({}, { duration: 0.4 })
+        }
 
         if (i < slides.length - 1) {
           tl.addLabel(`exit-${i}`)
@@ -133,9 +157,22 @@ export function ScrollProductShowcase() {
       })
 
       const totalDuration = tl.duration()
-      const snapPoints = Array.from(slides).map((_, i) =>
-        tl.labels[`hold-${i}`] / totalDuration
-      )
+
+      const snapPoints = []
+      slides.forEach((_, i) => {
+        if (i === MESSENGER_INDEX) {
+          for (let ch = 0; ch < MESSENGER_CHANNELS; ch++) {
+            snapPoints.push(tl.labels[`channel-${ch}`] / totalDuration)
+          }
+        } else {
+          snapPoints.push(tl.labels[`hold-${i}`] / totalDuration)
+        }
+      })
+
+      const slideHoldPoints = []
+      slides.forEach((_, i) => {
+        slideHoldPoints.push(tl.labels[`hold-${i}`] / totalDuration)
+      })
 
       ScrollTrigger.create({
         trigger: container,
@@ -155,8 +192,8 @@ export function ScrollProductShowcase() {
           const progress = self.progress
           let closest = 0
           let minDist = Infinity
-          for (let i = 0; i < snapPoints.length; i++) {
-            const dist = Math.abs(progress - snapPoints[i])
+          for (let i = 0; i < slideHoldPoints.length; i++) {
+            const dist = Math.abs(progress - slideHoldPoints[i])
             if (dist < minDist) {
               minDist = dist
               closest = i
@@ -205,6 +242,7 @@ export function ScrollProductShowcase() {
             product={product}
             index={i}
             isActive={isMobile || activeIndex === i}
+            messengerProgressRef={i === MESSENGER_INDEX ? messengerProgressRef : undefined}
           />
         ))}
         {!isMobile && (

--- a/components/sections/showcase/ProductSlide.jsx
+++ b/components/sections/showcase/ProductSlide.jsx
@@ -1,7 +1,7 @@
 import { SlideText } from './SlideText'
 import { SlideDevice } from './SlideDevice'
 
-export function ProductSlide({ product, index, isActive }) {
+export function ProductSlide({ product, index, isActive, messengerProgressRef }) {
   const isEven = index % 2 === 1
 
   return (
@@ -21,6 +21,7 @@ export function ProductSlide({ product, index, isActive }) {
             slug={product.slug}
             deviceType={product.deviceType}
             isActive={isActive}
+            messengerProgressRef={messengerProgressRef}
           />
         </div>
       </div>

--- a/components/sections/showcase/SlideDevice.jsx
+++ b/components/sections/showcase/SlideDevice.jsx
@@ -31,7 +31,7 @@ const TILT = {
   monitor: 'none',
 }
 
-export function SlideDevice({ slug, deviceType, isActive }) {
+export function SlideDevice({ slug, deviceType, isActive, messengerProgressRef }) {
   const Device = DEVICES[deviceType]
   const Screen = SCREENS[slug]
   const vibrate = deviceType === 'phone' && slug === 'receptionist'
@@ -50,6 +50,8 @@ export function SlideDevice({ slug, deviceType, isActive }) {
     }, 1800)
   }, [])
 
+  const isMessenger = slug === 'messenger'
+
   return (
     <div
       className="relative flex justify-center items-center scale-[0.72] md:scale-100 origin-center"
@@ -59,7 +61,6 @@ export function SlideDevice({ slug, deviceType, isActive }) {
       }}
       data-device
     >
-      {/* 3D scene container -- everything inside shares the same 3D space */}
       <div
         className="relative"
         style={{
@@ -67,14 +68,34 @@ export function SlideDevice({ slug, deviceType, isActive }) {
           transform: TILT[deviceType],
         }}
       >
-        {/* Floating cards at different Z depths (behind the phone) */}
         <FloatingCards slug={slug} highlightedCards={highlightedCards} />
 
-        {/* Device at z=0 (front layer) */}
         <div className="relative" style={{ transform: 'translateZ(0px)' }}>
-          <Device vibrate={vibrate && isActive} glass>
-            <Screen isActive={isActive} onAction={onAction} />
-          </Device>
+          {isMessenger ? (
+            <div className="relative" style={{ width: 320, height: 660 }}>
+              <Device glass>
+                <div className="w-full h-full bg-gray-50/50" />
+              </Device>
+              <div
+                className="absolute"
+                style={{
+                  top: 10, left: 10,
+                  width: 300, height: 640,
+                  overflow: 'visible',
+                }}
+              >
+                <Screen
+                  isActive={isActive}
+                  onAction={onAction}
+                  progressRef={messengerProgressRef}
+                />
+              </div>
+            </div>
+          ) : (
+            <Device vibrate={vibrate && isActive} glass>
+              <Screen isActive={isActive} onAction={onAction} />
+            </Device>
+          )}
         </div>
       </div>
     </div>

--- a/components/sections/showcase/screens/MessengerScreen.jsx
+++ b/components/sections/showcase/screens/MessengerScreen.jsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
-import { Send, Calendar, Bell, Ticket, Sparkles, MessageSquare, Globe, MessageCircle, Users } from 'lucide-react'
+import { useRef, useEffect } from 'react'
+import gsap from 'gsap'
+import { Calendar, Bell, Ticket, Send, MessageSquare, Globe, MessageCircle, Users } from 'lucide-react'
 import Logo from '@/components/ui/Logo'
 
 const CHANNELS = [
@@ -12,395 +12,235 @@ const CHANNELS = [
   { id: 'teams', label: 'Teams', icon: Users, color: '#5b5fc7' },
 ]
 
-const CHANNEL_SCRIPTS = {
-  0: [
-    { type: 'msg', role: 'user', text: 'Hey, do you have any openings this week?' },
-    { type: 'msg', role: 'ai', text: 'I have Thursday at 10 AM and Friday at 3 PM. Which works?' },
-    { type: 'msg', role: 'user', text: 'Thursday at 10, please.' },
-    { type: 'action', id: 'calendar', icon: Calendar, label: 'Appointment booked', sublabel: 'Thu, 10:00 AM' },
-    { type: 'msg', role: 'ai', text: "You're all set! I'll send a confirmation." },
-  ],
-  1: [
-    { type: 'msg', role: 'user', text: "What's on the lunch menu today?" },
-    { type: 'msg', role: 'ai', text: "Today's specials: Grilled Salmon, Pasta Primavera, and Thai Curry Bowl." },
-    { type: 'msg', role: 'user', text: 'Can you remind me about my appointment tomorrow?' },
-    { type: 'action', id: 'reminder', icon: Bell, label: 'Reminder set', sublabel: 'SMS at 9:00 AM' },
-    { type: 'msg', role: 'ai', text: "Done! You'll get an SMS at 9 AM tomorrow." },
-  ],
-  2: [
-    { type: 'msg', role: 'user', text: 'I need to reschedule my Friday meeting.' },
-    { type: 'msg', role: 'ai', text: 'Monday 2 PM or Tuesday 11 AM available. Preference?' },
-    { type: 'msg', role: 'user', text: 'Tuesday 11 works.' },
-    { type: 'action', id: 'reschedule', icon: Calendar, label: 'Rescheduled', sublabel: 'Tue, 11:00 AM' },
-    { type: 'msg', role: 'ai', text: 'Updated! Calendar invite sent.' },
-  ],
-  3: [
-    { type: 'msg', role: 'user', text: 'Can you create a support ticket for the billing issue?' },
-    { type: 'msg', role: 'ai', text: "I'll create that with all conversation details." },
-    { type: 'action', id: 'ticket', icon: Ticket, label: 'Ticket created', sublabel: 'Added to CRM' },
-    { type: 'msg', role: 'ai', text: 'Ticket #4821 assigned to your account manager.' },
-  ],
+const CONVERSATIONS = [
+  {
+    messages: [
+      { role: 'user', text: 'Hey, do you have any openings this week?' },
+      { role: 'ai', text: 'I have Thursday at 10 AM and Friday at 3 PM. Which works?' },
+      { role: 'user', text: 'Thursday at 10, please.' },
+    ],
+    action: { icon: Calendar, label: 'Appointment booked', sublabel: 'Thu, 10:00 AM' },
+    finalMsg: "You're all set! I'll send a confirmation.",
+  },
+  {
+    messages: [
+      { role: 'user', text: "What's on the lunch menu today?" },
+      { role: 'ai', text: "Today's specials: Grilled Salmon, Pasta Primavera, and Thai Curry Bowl." },
+      { role: 'user', text: 'Can you remind me about my appointment tomorrow?' },
+    ],
+    action: { icon: Bell, label: 'Reminder set', sublabel: 'SMS at 9:00 AM' },
+    finalMsg: "Done! You'll get an SMS at 9 AM tomorrow.",
+  },
+  {
+    messages: [
+      { role: 'user', text: 'I need to reschedule my Friday meeting.' },
+      { role: 'ai', text: 'Monday 2 PM or Tuesday 11 AM available. Preference?' },
+      { role: 'user', text: 'Tuesday 11 works.' },
+    ],
+    action: { icon: Calendar, label: 'Rescheduled', sublabel: 'Tue, 11:00 AM' },
+    finalMsg: 'Updated! Calendar invite sent.',
+  },
+  {
+    messages: [
+      { role: 'user', text: 'Can you create a support ticket for the billing issue?' },
+      { role: 'ai', text: "I'll create that with all conversation details." },
+    ],
+    action: { icon: Ticket, label: 'Ticket created', sublabel: 'Added to CRM' },
+    finalMsg: 'Ticket #4821 assigned to your account manager.',
+  },
+]
+
+const STACK_OFFSETS = [
+  { x: 0, y: 0, scale: 1, opacity: 1 },
+  { x: 14, y: -22, scale: 0.94, opacity: 0.65 },
+  { x: 26, y: -42, scale: 0.88, opacity: 0.4 },
+  { x: 36, y: -58, scale: 0.83, opacity: 0.25 },
+]
+
+function lerp(a, b, t) {
+  return a + (b - a) * t
 }
 
-const LOOP_DURATION = 40000
-const TYPE_DUR = 1000
-const MSG_GAP = 400
-const USER_GAP = 500
-const ACTION_LEAD = 200
-const ACTION_DUR = 1000
-const ACTION_TAIL = 300
-const CHANNEL_SWITCH = 1200
-
-function ChannelStrip({ channel, isActive }) {
+function ChannelCard({ channel, conversation }) {
   const Icon = channel.icon
-  return (
-    <motion.div
-      layout
-      className="flex items-center gap-2 px-2.5 overflow-hidden"
-      animate={{
-        height: isActive ? 32 : 22,
-        opacity: isActive ? 1 : 0.45,
-      }}
-      transition={{ duration: 0.5, ease: [0.22, 1, 0.36, 1] }}
-      style={{
-        borderLeft: isActive ? `3px solid ${channel.color}` : '3px solid transparent',
-        background: isActive ? `${channel.color}08` : 'transparent',
-      }}
-    >
-      <div
-        className="shrink-0 rounded flex items-center justify-center"
-        style={{
-          width: isActive ? 18 : 14,
-          height: isActive ? 18 : 14,
-          backgroundColor: `${channel.color}15`,
-          transition: 'width 0.4s, height 0.4s',
-        }}
-      >
-        <Icon size={isActive ? 10 : 8} strokeWidth={1.5} style={{ color: channel.color }} />
-      </div>
-      <span
-        className="font-semibold truncate"
-        style={{
-          fontSize: isActive ? 10 : 8,
-          color: isActive ? channel.color : '#999',
-          transition: 'font-size 0.4s, color 0.4s',
-        }}
-      >
-        {channel.label}
-      </span>
-      {isActive && (
-        <motion.div
-          initial={{ scale: 0 }}
-          animate={{ scale: 1 }}
-          className="ml-auto w-1.5 h-1.5 rounded-full shrink-0"
-          style={{ backgroundColor: channel.color }}
-        />
-      )}
-    </motion.div>
-  )
-}
+  const ActionIcon = conversation.action.icon
 
-function ChatBubble({ msg }) {
-  const isUser = msg.role === 'user'
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 6 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.25, ease: 'easeOut' }}
-      className={`flex mb-1.5 ${isUser ? 'justify-end' : 'items-end gap-1.5'}`}
-    >
-      {!isUser && (
+    <div className="w-full h-full flex flex-col bg-white overflow-hidden" style={{ borderRadius: 30 }}>
+      <div
+        className="flex items-center gap-2 px-3 shrink-0"
+        style={{ paddingTop: 28, paddingBottom: 8, borderBottom: `2px solid ${channel.color}15` }}
+      >
         <div
-          className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
-          style={{ background: 'linear-gradient(135deg, #4a6fc2, #3859a8)' }}
+          className="w-7 h-7 rounded-lg flex items-center justify-center"
+          style={{ backgroundColor: `${channel.color}15` }}
         >
-          <Logo size={9} tone="on-dark" animate={false} />
+          <Icon size={14} strokeWidth={1.5} style={{ color: channel.color }} />
         </div>
-      )}
-      <div
-        className={`max-w-[78%] px-2.5 py-1.5 text-[10px] leading-[1.4] ${
-          isUser ? 'rounded-xl rounded-br-sm text-white' : 'rounded-xl rounded-bl-sm text-gray-900'
-        }`}
-        style={{ backgroundColor: isUser ? '#3859a8' : '#f1f3f5' }}
-      >
-        {msg.text}
+        <div>
+          <p className="text-[11px] font-bold" style={{ color: channel.color }}>{channel.label}</p>
+          <p className="text-[8px] text-gray-400">JotilLabs AI</p>
+        </div>
+        <div className="ml-auto flex items-center gap-1">
+          <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
+          <span className="text-[8px] text-green-600">Online</span>
+        </div>
       </div>
-    </motion.div>
-  )
-}
 
-function BlingAction({ action }) {
-  const Icon = action.icon
-  return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      className="flex flex-col items-center py-2 my-1"
-    >
-      <div className="relative">
-        {[0, 1, 2, 3].map((i) => (
+      <div className="flex-1 px-3 py-2 overflow-hidden">
+        {conversation.messages.map((msg, i) => (
           <div
             key={i}
-            className="absolute"
-            style={{
-              width: 6, height: 6,
-              top: '50%', left: '50%',
-              marginTop: [-14, -14, 8, 8][i],
-              marginLeft: [-14, 8, -14, 8][i],
-              animation: `bling-sparkle 0.8s ease-out ${i * 0.1}s`,
-              animationFillMode: 'forwards',
-              opacity: 0,
-            }}
+            className={`flex mb-1.5 ${msg.role === 'user' ? 'justify-end' : 'items-end gap-1.5'}`}
           >
-            <Sparkles size={6} className="text-amber-400" />
+            {msg.role === 'ai' && (
+              <div
+                className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
+                style={{ background: 'linear-gradient(135deg, #4a6fc2, #3859a8)' }}
+              >
+                <Logo size={9} tone="on-dark" animate={false} />
+              </div>
+            )}
+            <div
+              className={`max-w-[78%] px-2.5 py-1.5 text-[10px] leading-[1.4] ${
+                msg.role === 'user'
+                  ? 'rounded-xl rounded-br-sm text-white'
+                  : 'rounded-xl rounded-bl-sm text-gray-900'
+              }`}
+              style={{ backgroundColor: msg.role === 'user' ? channel.color : '#f1f3f5' }}
+            >
+              {msg.text}
+            </div>
           </div>
         ))}
-        <div
-          className="w-9 h-9 rounded-xl flex items-center justify-center"
-          style={{
-            background: 'linear-gradient(135deg, rgba(56,89,168,0.12), rgba(56,89,168,0.06))',
-            animation: 'bling-in 0.5s ease-out',
-          }}
-        >
-          <Icon size={16} strokeWidth={1.5} style={{ color: '#3859a8' }} />
+
+        <div className="flex flex-col items-center py-2 my-1">
+          <div
+            className="w-8 h-8 rounded-xl flex items-center justify-center"
+            style={{ background: `linear-gradient(135deg, ${channel.color}18, ${channel.color}08)` }}
+          >
+            <ActionIcon size={14} strokeWidth={1.5} style={{ color: channel.color }} />
+          </div>
+          <div className="flex items-center gap-1 mt-1">
+            <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
+            <span className="text-[8px] font-semibold" style={{ color: channel.color }}>
+              {conversation.action.label}
+            </span>
+            <span className="text-[7px] text-gray-400">{conversation.action.sublabel}</span>
+          </div>
+        </div>
+
+        <div className="flex items-end gap-1.5 mb-1.5">
+          <div
+            className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
+            style={{ background: 'linear-gradient(135deg, #4a6fc2, #3859a8)' }}
+          >
+            <Logo size={9} tone="on-dark" animate={false} />
+          </div>
+          <div className="max-w-[78%] px-2.5 py-1.5 text-[10px] leading-[1.4] rounded-xl rounded-bl-sm text-gray-900 bg-[#f1f3f5]">
+            {conversation.finalMsg}
+          </div>
         </div>
       </div>
-      <motion.div
-        initial={{ opacity: 0, y: 4 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.3, duration: 0.2 }}
-        className="flex items-center gap-1 mt-1.5"
-      >
-        <div className="w-3 h-3 rounded-full bg-green-500/15 flex items-center justify-center">
-          <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
-        </div>
-        <span className="text-[9px] font-semibold" style={{ color: '#3859a8' }}>{action.label}</span>
-        <span className="text-[8px] text-gray-400">{action.sublabel}</span>
-      </motion.div>
-    </motion.div>
-  )
-}
 
-function TypingIndicator() {
-  return (
-    <div className="flex justify-start mb-1.5">
-      <div className="flex items-end gap-1.5">
+      <div className="shrink-0 px-3 py-2 border-t border-gray-100 flex items-center gap-2">
         <div
-          className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
-          style={{ background: 'linear-gradient(135deg, #4a6fc2, #3859a8)' }}
+          className="w-6 h-6 rounded-full flex items-center justify-center shrink-0"
+          style={{ background: `linear-gradient(135deg, ${channel.color}, ${channel.color}cc)` }}
         >
-          <Logo size={9} tone="on-dark" animate={false} />
+          <Logo size={10} tone="on-dark" animate={false} />
         </div>
-        <div className="flex items-center gap-[3px] px-3 py-2 rounded-xl rounded-bl-sm bg-[#f1f3f5]">
-          {[0, 1, 2].map((i) => (
-            <div
-              key={i}
-              className="w-[5px] h-[5px] rounded-full"
-              style={{
-                backgroundColor: '#9ca3af',
-                animation: `typing-dot 1.2s ease-in-out ${i * 0.15}s infinite`,
-              }}
-            />
-          ))}
+        <div className="flex-1 bg-gray-50 rounded-full px-3 py-1 text-[9px] text-gray-400">
+          Type a message...
+        </div>
+        <div
+          className="w-6 h-6 rounded-full flex items-center justify-center shrink-0"
+          style={{ backgroundColor: channel.color }}
+        >
+          <Send className="w-3 h-3 text-white" strokeWidth={1.5} />
         </div>
       </div>
     </div>
   )
 }
 
-export function MessengerScreen({ isActive, onAction }) {
-  const [items, setItems] = useState([])
-  const [activeChannel, setActiveChannel] = useState(0)
-  const [isTyping, setIsTyping] = useState(false)
-  const [blingAction, setBlingAction] = useState(null)
-  const scrollRef = useRef(null)
-  const loopRef = useRef(null)
-
-  useEffect(() => {
-    if (scrollRef.current) {
-      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
-    }
-  }, [items, isTyping, blingAction])
+export function MessengerScreen({ isActive, onAction, progressRef }) {
+  const cardRefs = useRef([])
+  const tickerRef = useRef(null)
 
   useEffect(() => {
     if (!isActive) {
-      setItems([])
-      setActiveChannel(0)
-      setIsTyping(false)
-      setBlingAction(null)
-      if (loopRef.current) loopRef.current.forEach(clearTimeout)
+      cardRefs.current.forEach((card) => {
+        if (card) gsap.set(card, { clearProps: 'all' })
+      })
       return
     }
 
-    const timers = []
-    const schedule = (fn, ms) => {
-      const id = setTimeout(fn, ms)
-      timers.push(id)
-      return id
-    }
+    const updateCards = () => {
+      const progress = progressRef?.current ?? 0
+      const activeFloat = progress * (CHANNELS.length - 1)
 
-    const playChannel = (chIdx, startAt) => {
-      let t = startAt
-      const script = CHANNEL_SCRIPTS[chIdx]
+      cardRefs.current.forEach((card, i) => {
+        if (!card) return
 
-      script.forEach((step) => {
-        if (step.type === 'msg') {
-          if (step.role === 'ai') {
-            schedule(() => setIsTyping(true), t)
-            t += TYPE_DUR
-            const msg = step
-            schedule(() => {
-              setIsTyping(false)
-              setItems((prev) => [...prev, msg])
-            }, t)
-            t += MSG_GAP
-          } else {
-            const msg = step
-            schedule(() => setItems((prev) => [...prev, msg]), t)
-            t += USER_GAP
-          }
-        } else if (step.type === 'action') {
-          t += ACTION_LEAD
-          const action = step
-          schedule(() => {
-            setBlingAction(action)
-            if (onAction) onAction(action.id)
-          }, t)
-          t += ACTION_DUR
-          schedule(() => {
-            setBlingAction(null)
-            setItems((prev) => [...prev, action])
-          }, t)
-          t += ACTION_TAIL
+        const rawDepth = i - activeFloat
+
+        if (rawDepth < -0.8) {
+          gsap.set(card, { x: -30, y: 30, scale: 0.8, opacity: 0, zIndex: 0 })
+        } else if (rawDepth < 0) {
+          const t = (rawDepth + 0.8) / 0.8
+          gsap.set(card, {
+            x: lerp(-30, STACK_OFFSETS[0].x, t),
+            y: lerp(30, STACK_OFFSETS[0].y, t),
+            scale: lerp(0.8, STACK_OFFSETS[0].scale, t),
+            opacity: lerp(0, STACK_OFFSETS[0].opacity, t),
+            zIndex: 10,
+          })
+        } else {
+          const floor = Math.floor(rawDepth)
+          const ceil = Math.min(floor + 1, 3)
+          const frac = rawDepth - floor
+          const fromIdx = Math.min(floor, 3)
+          const toIdx = Math.min(ceil, 3)
+          const from = STACK_OFFSETS[fromIdx]
+          const to = STACK_OFFSETS[toIdx]
+
+          gsap.set(card, {
+            x: lerp(from.x, to.x, frac),
+            y: lerp(from.y, to.y, frac),
+            scale: lerp(from.scale, to.scale, frac),
+            opacity: lerp(from.opacity, to.opacity, frac),
+            zIndex: 10 - Math.round(rawDepth),
+          })
         }
       })
-
-      return t
     }
 
-    const runLoop = () => {
-      setItems([])
-      setActiveChannel(0)
-      setIsTyping(false)
-      setBlingAction(null)
+    gsap.ticker.add(updateCards)
+    tickerRef.current = updateCards
 
-      let t = 600
-      t = playChannel(0, t)
-
-      for (let ch = 1; ch < CHANNELS.length; ch++) {
-        t += 400
-        const chIdx = ch
-        schedule(() => {
-          setActiveChannel(chIdx)
-          setItems([])
-          setIsTyping(false)
-          setBlingAction(null)
-        }, t)
-        t += 800
-        t = playChannel(chIdx, t)
-      }
-
-      schedule(runLoop, Math.max(t + 2000, LOOP_DURATION))
+    return () => {
+      gsap.ticker.remove(updateCards)
     }
-
-    runLoop()
-    loopRef.current = timers
-    return () => timers.forEach(clearTimeout)
-  }, [isActive, onAction])
+  }, [isActive, progressRef])
 
   return (
-    <div className="w-full h-full flex flex-col bg-white text-[11px] relative overflow-hidden">
-      {/* Channel strip stack */}
-      <div className="pt-7 shrink-0 border-b border-gray-100">
-        {CHANNELS.map((ch, i) => (
-          <ChannelStrip key={ch.id} channel={ch} isActive={activeChannel === i} />
-        ))}
-      </div>
-
-      {/* Chat header */}
-      <div className="flex items-center gap-2 px-3 py-1.5 border-b border-gray-50 shrink-0">
+    <div className="relative" style={{ width: 300, height: 640 }}>
+      {CHANNELS.map((ch, i) => (
         <div
-          className="w-6 h-6 rounded-full flex items-center justify-center shrink-0"
-          style={{ background: 'linear-gradient(135deg, #4a6fc2, #3859a8)' }}
-        >
-          <Logo size={11} tone="on-dark" animate={false} />
-        </div>
-        <div>
-          <p className="text-[11px] font-semibold text-gray-900">JotilLabs AI</p>
-          <p className="text-[9px] text-green-600 flex items-center gap-1">
-            <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
-            Online now
-          </p>
-        </div>
-      </div>
-
-      {/* Messages */}
-      <div ref={scrollRef} className="flex-1 px-2.5 py-1.5 overflow-hidden">
-        <AnimatePresence mode="popLayout">
-          {items.map((item, i) => {
-            if (item.type === 'msg') {
-              return <ChatBubble key={`msg-${activeChannel}-${i}`} msg={item} />
-            }
-            if (item.type === 'action') {
-              return (
-                <motion.div
-                  key={`action-${activeChannel}-${item.id}`}
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                >
-                  <BlingAction action={item} />
-                </motion.div>
-              )
-            }
-            return null
-          })}
-
-          {isTyping && (
-            <motion.div
-              key={`typing-${activeChannel}-${items.length}`}
-              initial={{ opacity: 0, y: 4 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, scale: 0.8 }}
-              transition={{ duration: 0.2 }}
-            >
-              <TypingIndicator />
-            </motion.div>
-          )}
-
-          {blingAction && (
-            <motion.div
-              key={`bling-${activeChannel}-${blingAction.id}`}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-            >
-              <BlingAction action={blingAction} />
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </div>
-
-      {/* Bottom input bar */}
-      <div className="shrink-0 px-3 py-2 border-t border-gray-100 flex items-center gap-2">
-        <div
-          className="w-7 h-7 rounded-full flex items-center justify-center shrink-0"
+          key={ch.id}
+          ref={(el) => { cardRefs.current[i] = el }}
+          className="absolute inset-0"
           style={{
-            background: isTyping
-              ? 'linear-gradient(135deg, #4a6fc2, #3859a8, #6366F1)'
-              : 'linear-gradient(135deg, #4a6fc2, #3859a8)',
-            boxShadow: isTyping
-              ? '0 0 8px rgba(56,89,168,0.3)'
-              : '0 2px 6px rgba(56,89,168,0.15)',
-            transition: 'background 0.4s, box-shadow 0.4s',
+            willChange: 'transform, opacity',
+            boxShadow: '0 8px 30px rgba(0,0,0,0.12), 0 2px 8px rgba(0,0,0,0.06)',
+            borderRadius: 30,
+            overflow: 'hidden',
           }}
         >
-          <Logo size={11} tone="on-dark" animate={false} />
+          <ChannelCard channel={ch} conversation={CONVERSATIONS[i]} />
         </div>
-        <div className="flex-1 bg-gray-50 rounded-full px-3 py-1.5 text-[10px] text-gray-400">Type a message...</div>
-        <div className="w-7 h-7 rounded-full flex items-center justify-center shrink-0" style={{ backgroundColor: '#3859a8' }}>
-          <Send className="w-3.5 h-3.5 text-white" strokeWidth={1.5} />
-        </div>
-      </div>
+      ))}
     </div>
   )
 }

--- a/components/sections/showcase/screens/MessengerScreen.jsx
+++ b/components/sections/showcase/screens/MessengerScreen.jsx
@@ -52,9 +52,9 @@ const CONVERSATIONS = [
 
 const STACK_OFFSETS = [
   { x: 0, y: 0, scale: 1, opacity: 1 },
-  { x: 14, y: -22, scale: 0.94, opacity: 0.65 },
-  { x: 26, y: -42, scale: 0.88, opacity: 0.4 },
-  { x: 36, y: -58, scale: 0.83, opacity: 0.25 },
+  { x: 18, y: -28, scale: 0.93, opacity: 0.7 },
+  { x: 34, y: -52, scale: 0.86, opacity: 0.45 },
+  { x: 48, y: -72, scale: 0.8, opacity: 0.25 },
 ]
 
 function lerp(a, b, t) {
@@ -139,6 +139,28 @@ function ChannelCard({ channel, conversation }) {
           </div>
           <div className="max-w-[78%] px-2.5 py-1.5 text-[10px] leading-[1.4] rounded-xl rounded-bl-sm text-gray-900 bg-[#f1f3f5]">
             {conversation.finalMsg}
+          </div>
+        </div>
+
+        <div className="flex items-end gap-1.5">
+          <div
+            className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
+            style={{ background: 'linear-gradient(135deg, #4a6fc2, #3859a8)' }}
+          >
+            <Logo size={9} tone="on-dark" animate={false} />
+          </div>
+          <div className="flex items-center gap-[3px] px-2.5 py-2 rounded-xl rounded-bl-sm bg-[#f1f3f5]">
+            {[0, 1, 2].map((dot) => (
+              <div
+                key={dot}
+                className="w-[5px] h-[5px] rounded-full"
+                style={{
+                  backgroundColor: channel.color,
+                  opacity: 0.5,
+                  animation: `typing-dot 1.4s ease-in-out ${dot * 0.2}s infinite`,
+                }}
+              />
+            ))}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Replace single-phone tab layout with fanned card deck where each channel (SMS, Web Chat, WhatsApp, Teams) is a separate card with its own static conversation
- GSAP ScrollTrigger drives channel transitions with 4x scroll range and channel sub-snap points
- Shared progress ref + GSAP ticker at 60fps for smooth interpolated card positioning with depth cues (x/y offset, scale, opacity)
- PhoneMockup rendered as background with card stack overlaid via absolute positioning with overflow:visible

## Test plan
- [ ] Scroll to Messenger slide on desktop, verify 4 channel cards fan like a deck
- [ ] Scroll through all 4 channels (SMS -> Web Chat -> WhatsApp -> Teams), verify smooth transitions
- [ ] Verify each card shows its own conversation with channel-colored messages and action indicators
- [ ] Verify snap points work for each channel position
- [ ] Verify other slides (Receptionist, Outreach, Space, Avatar) still work correctly
- [ ] Test mobile layout (cards should not animate, all content visible)
- [ ] Build passes with no errors