### PR TITLE
feat(space): scroll-driven 3-scene SpaceScreen

### DIFF
--- a/components/sections/ScrollProductShowcase.jsx
+++ b/components/sections/ScrollProductShowcase.jsx
@@ -13,10 +13,14 @@ gsap.registerPlugin(useGSAP, ScrollTrigger)
 
 const MESSENGER_INDEX = 1
 const MESSENGER_CHANNELS = 4
+const SPACE_INDEX = 3
+const SPACE_SCENES = 3
 const BASE_SCROLL = 1200
-const TOTAL_SCROLL = PRODUCT_SLIDES.reduce((sum, _, i) =>
-  sum + (i === MESSENGER_INDEX ? BASE_SCROLL * MESSENGER_CHANNELS : BASE_SCROLL), 0
-)
+const TOTAL_SCROLL = PRODUCT_SLIDES.reduce((sum, _, i) => {
+  if (i === MESSENGER_INDEX) return sum + BASE_SCROLL * MESSENGER_CHANNELS
+  if (i === SPACE_INDEX) return sum + BASE_SCROLL * SPACE_SCENES
+  return sum + BASE_SCROLL
+}, 0)
 
 function ProgressDots({ activeIndex, total }) {
   return (
@@ -65,6 +69,7 @@ export function ScrollProductShowcase() {
   const [activeIndex, setActiveIndex] = useState(0)
   const [isMobile, setIsMobile] = useState(false)
   const messengerProgressRef = useRef(0)
+  const spaceProgressRef = useRef(0)
 
   useGSAP(() => {
     const container = containerRef.current
@@ -130,6 +135,23 @@ export function ScrollProductShowcase() {
               messengerProgressRef.current = proxy.progress
             },
           })
+        } else if (i === SPACE_INDEX) {
+          const holdDur = 0.4 * SPACE_SCENES
+          const proxy = { progress: 0 }
+
+          tl.addLabel(`hold-${i}`)
+          for (let sc = 0; sc < SPACE_SCENES; sc++) {
+            tl.addLabel(`space-scene-${sc}`, `hold-${i}+=${(sc / SPACE_SCENES) * holdDur}`)
+          }
+
+          tl.to(proxy, {
+            progress: 1,
+            duration: holdDur,
+            ease: 'none',
+            onUpdate: () => {
+              spaceProgressRef.current = proxy.progress
+            },
+          })
         } else {
           tl.addLabel(`hold-${i}`)
           tl.to({}, { duration: 0.4 })
@@ -163,6 +185,10 @@ export function ScrollProductShowcase() {
         if (i === MESSENGER_INDEX) {
           for (let ch = 0; ch < MESSENGER_CHANNELS; ch++) {
             snapPoints.push(tl.labels[`channel-${ch}`] / totalDuration)
+          }
+        } else if (i === SPACE_INDEX) {
+          for (let sc = 0; sc < SPACE_SCENES; sc++) {
+            snapPoints.push(tl.labels[`space-scene-${sc}`] / totalDuration)
           }
         } else {
           snapPoints.push(tl.labels[`hold-${i}`] / totalDuration)
@@ -243,6 +269,7 @@ export function ScrollProductShowcase() {
             index={i}
             isActive={isMobile || activeIndex === i}
             messengerProgressRef={i === MESSENGER_INDEX ? messengerProgressRef : undefined}
+            spaceProgressRef={i === SPACE_INDEX ? spaceProgressRef : undefined}
           />
         ))}
         {!isMobile && (

--- a/components/sections/showcase/ProductSlide.jsx
+++ b/components/sections/showcase/ProductSlide.jsx
@@ -1,7 +1,7 @@
 import { SlideText } from './SlideText'
 import { SlideDevice } from './SlideDevice'
 
-export function ProductSlide({ product, index, isActive, messengerProgressRef }) {
+export function ProductSlide({ product, index, isActive, messengerProgressRef, spaceProgressRef }) {
   const isEven = index % 2 === 1
 
   return (
@@ -22,6 +22,7 @@ export function ProductSlide({ product, index, isActive, messengerProgressRef })
             deviceType={product.deviceType}
             isActive={isActive}
             messengerProgressRef={messengerProgressRef}
+            spaceProgressRef={spaceProgressRef}
           />
         </div>
       </div>

--- a/components/sections/showcase/SlideDevice.jsx
+++ b/components/sections/showcase/SlideDevice.jsx
@@ -31,7 +31,7 @@ const TILT = {
   monitor: 'none',
 }
 
-export function SlideDevice({ slug, deviceType, isActive, messengerProgressRef }) {
+export function SlideDevice({ slug, deviceType, isActive, messengerProgressRef, spaceProgressRef }) {
   const Device = DEVICES[deviceType]
   const Screen = SCREENS[slug]
   const vibrate = deviceType === 'phone' && slug === 'receptionist'
@@ -93,7 +93,11 @@ export function SlideDevice({ slug, deviceType, isActive, messengerProgressRef }
             </div>
           ) : (
             <Device vibrate={vibrate && isActive} glass>
-              <Screen isActive={isActive} onAction={onAction} />
+              <Screen
+                isActive={isActive}
+                onAction={onAction}
+                progressRef={spaceProgressRef}
+              />
             </Device>
           )}
         </div>

--- a/components/sections/showcase/screens/SpaceScreen.jsx
+++ b/components/sections/showcase/screens/SpaceScreen.jsx
@@ -1,133 +1,288 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
-import { MessageCircle, Users, BarChart3, Cpu, Settings } from 'lucide-react'
+import { useRef, useEffect } from 'react'
+import gsap from 'gsap'
+import { MessageCircle, Users, BarChart3, Cpu, Settings, Check, Calendar, Loader2 } from 'lucide-react'
+import Logo from '@/components/ui/Logo'
 
-const sidebarIcons = [MessageCircle, Users, BarChart3, Cpu, Settings]
+const SIDEBAR_ICONS = [MessageCircle, Users, BarChart3, Cpu, Settings]
 
-const PROMPT_TEXT = 'Compare response quality for receptionist v2.1 vs v2.3'
-const RESPONSE_V1 = 'Response quality: 87%. Average handle time: 45s. Customer satisfaction: 4.2/5.'
-const RESPONSE_V2 = 'Response quality: 94%. Average handle time: 38s. Customer satisfaction: 4.7/5.'
+const SCENE_SIDEBAR_ACTIVE = [3, 0, 1]
 
-const LOOP_DURATION = 10000
+const MODELS = [
+  { name: 'GPT-4', tag: 'Fast reasoning', color: '#10a37f' },
+  { name: 'Claude', tag: 'Long context', color: '#d97706' },
+  { name: 'Gemini', tag: 'Multimodal', color: '#4285f4' },
+  { name: 'Llama 3', tag: 'Open source', color: '#7c3aed' },
+]
 
-export function SpaceScreen({ isActive, onAction }) {
-  const [typedChars, setTypedChars] = useState(0)
-  const [responseChars1, setResponseChars1] = useState(0)
-  const [responseChars2, setResponseChars2] = useState(0)
-  const [showMetrics, setShowMetrics] = useState(false)
-  const loopRef = useRef(null)
+const SELECTED_MODEL = 1
+
+const CHAT_MESSAGES = [
+  { role: 'user', text: 'Summarize today\'s missed calls and suggest follow-ups' },
+  { role: 'ai', text: 'You had 3 missed calls today. Two from returning clients asking about pricing. I recommend a follow-up text with your rate sheet. One new lead from Google Ads. I suggest an immediate callback.' },
+  { role: 'user', text: 'Schedule the callback for 2 PM' },
+]
+
+function Sidebar({ activeScene }) {
+  const activeIdx = SCENE_SIDEBAR_ACTIVE[activeScene] ?? 3
+  return (
+    <div className="w-10 bg-white border-r border-gray-100 flex flex-col items-center py-3 gap-3 shrink-0">
+      {SIDEBAR_ICONS.map((Icon, i) => (
+        <div
+          key={i}
+          className="w-7 h-7 rounded-lg flex items-center justify-center transition-colors duration-300"
+          style={{ backgroundColor: i === activeIdx ? 'rgba(56, 89, 168, 0.1)' : 'transparent' }}
+        >
+          <Icon className="w-3.5 h-3.5" strokeWidth={1.5} style={{ color: i === activeIdx ? '#3859a8' : '#a0a0a0' }} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function ModelSelectionScene({ progress }) {
+  return (
+    <div className="flex-1 flex flex-col p-3 min-w-0">
+      <div className="flex items-center justify-between mb-2.5">
+        <p className="text-[11px] font-semibold text-gray-900">Select a Model</p>
+        <div className="px-2 py-0.5 rounded-full text-[8px] font-medium text-white" style={{ backgroundColor: '#3859a8' }}>
+          Configure
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-2">
+        {MODELS.map((model, i) => {
+          const isSelected = i === SELECTED_MODEL && progress > 0.4
+          return (
+            <div
+              key={model.name}
+              className="rounded-lg border p-2 relative transition-all duration-300"
+              style={{
+                borderColor: isSelected ? model.color : '#e5e7eb',
+                backgroundColor: isSelected ? `${model.color}08` : '#fff',
+                transform: isSelected ? 'scale(1.02)' : 'scale(1)',
+              }}
+            >
+              {isSelected && (
+                <div
+                  className="absolute top-1.5 right-1.5 w-4 h-4 rounded-full flex items-center justify-center"
+                  style={{ backgroundColor: model.color }}
+                >
+                  <Check className="w-2.5 h-2.5 text-white" strokeWidth={2.5} />
+                </div>
+              )}
+              <div className="flex items-center gap-1.5 mb-1">
+                <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: model.color }} />
+                <p className="text-[10px] font-semibold text-gray-900">{model.name}</p>
+              </div>
+              <p className="text-[8px] text-gray-400">{model.tag}</p>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function ChatScene() {
+  const selectedModel = MODELS[SELECTED_MODEL]
+  return (
+    <div className="flex-1 flex flex-col p-3 min-w-0">
+      <div className="flex items-center justify-between mb-2.5">
+        <div className="flex items-center gap-1.5">
+          <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: selectedModel.color }} />
+          <p className="text-[11px] font-semibold text-gray-900">{selectedModel.name} Chat</p>
+        </div>
+        <div className="flex items-center gap-1">
+          <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
+          <span className="text-[8px] text-green-600">Online</span>
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-hidden">
+        {CHAT_MESSAGES.map((msg, i) => (
+          <div
+            key={i}
+            className={`flex mb-1.5 ${msg.role === 'user' ? 'justify-end' : 'items-end gap-1.5'}`}
+          >
+            {msg.role === 'ai' && (
+              <div
+                className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
+                style={{ background: `linear-gradient(135deg, ${selectedModel.color}, ${selectedModel.color}cc)` }}
+              >
+                <Logo size={9} tone="on-dark" animate={false} />
+              </div>
+            )}
+            <div
+              className={`max-w-[80%] px-2 py-1.5 text-[9px] leading-[1.4] ${
+                msg.role === 'user'
+                  ? 'rounded-xl rounded-br-sm text-white'
+                  : 'rounded-xl rounded-bl-sm text-gray-900 bg-[#f1f3f5]'
+              }`}
+              style={msg.role === 'user' ? { backgroundColor: '#3859a8' } : undefined}
+            >
+              {msg.text}
+            </div>
+          </div>
+        ))}
+
+        <div className="flex flex-col items-center py-2 my-1">
+          <div className="w-7 h-7 rounded-xl flex items-center justify-center" style={{ background: 'rgba(56, 89, 168, 0.08)' }}>
+            <Calendar size={12} strokeWidth={1.5} style={{ color: '#3859a8' }} />
+          </div>
+          <div className="flex items-center gap-1 mt-1">
+            <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
+            <span className="text-[8px] font-semibold" style={{ color: '#3859a8' }}>Callback scheduled</span>
+            <span className="text-[7px] text-gray-400">2:00 PM</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="shrink-0 pt-1.5 border-t border-gray-100 flex items-center gap-2">
+        <div className="flex-1 bg-gray-50 rounded-full px-2.5 py-1 text-[8px] text-gray-400">
+          Type a message...
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function AgentCreationScene({ progress }) {
+  const subProgress = (progress - 0.66) / 0.34
+  const phase = subProgress < 0.33 ? 'form' : subProgress < 0.66 ? 'creating' : 'success'
+
+  return (
+    <div className="flex-1 flex flex-col p-3 min-w-0">
+      <div className="flex items-center justify-between mb-2.5">
+        <p className="text-[11px] font-semibold text-gray-900">Create New Agent</p>
+      </div>
+
+      <div className="flex-1 flex items-start justify-center pt-2">
+        <div className="w-full rounded-lg border border-gray-200 bg-white p-3">
+          <div className="space-y-2 mb-3">
+            <div>
+              <p className="text-[8px] text-gray-400 mb-0.5">Name</p>
+              <p className="text-[10px] text-gray-900 font-medium">Sales Assistant</p>
+            </div>
+            <div>
+              <p className="text-[8px] text-gray-400 mb-0.5">Model</p>
+              <div className="flex items-center gap-1">
+                <div className="w-2 h-2 rounded-full" style={{ backgroundColor: MODELS[SELECTED_MODEL].color }} />
+                <p className="text-[10px] text-gray-900 font-medium">{MODELS[SELECTED_MODEL].name}</p>
+              </div>
+            </div>
+            <div>
+              <p className="text-[8px] text-gray-400 mb-0.5">Purpose</p>
+              <p className="text-[10px] text-gray-900 font-medium">Follow-up & scheduling</p>
+            </div>
+          </div>
+
+          {phase === 'form' && (
+            <button
+              className="w-full py-1.5 rounded-lg text-[10px] font-semibold text-white"
+              style={{ backgroundColor: '#3859a8' }}
+            >
+              Create Agent
+            </button>
+          )}
+
+          {phase === 'creating' && (
+            <div className="w-full py-1.5 rounded-lg text-[10px] font-semibold text-white flex items-center justify-center gap-1.5" style={{ backgroundColor: '#3859a8' }}>
+              <Loader2 className="w-3 h-3 animate-spin" />
+              Creating...
+            </div>
+          )}
+
+          {phase === 'success' && (
+            <div className="w-full py-2 rounded-lg border border-green-200 bg-green-50 flex flex-col items-center gap-1">
+              <div className="w-5 h-5 rounded-full bg-green-500 flex items-center justify-center">
+                <Check className="w-3 h-3 text-white" strokeWidth={2.5} />
+              </div>
+              <p className="text-[10px] font-semibold text-green-700">Agent Created</p>
+              <div className="flex items-center gap-1">
+                <p className="text-[9px] text-gray-600">Sales Assistant</p>
+                <span className="px-1.5 py-0.5 rounded-full text-[7px] font-medium bg-green-100 text-green-700">Active</span>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function SpaceScreen({ isActive, onAction, progressRef }) {
+  const sceneRefs = useRef([])
+  const tickerRef = useRef(null)
+  const sceneIndexRef = useRef(0)
 
   useEffect(() => {
     if (!isActive) {
-      setTypedChars(0)
-      setResponseChars1(0)
-      setResponseChars2(0)
-      setShowMetrics(false)
-      if (loopRef.current) loopRef.current.forEach(clearTimeout)
+      sceneRefs.current.forEach((el) => {
+        if (el) gsap.set(el, { clearProps: 'all' })
+      })
       return
     }
 
-    const timers = []
-    const schedule = (fn, ms) => { const id = setTimeout(fn, ms); timers.push(id); return id }
+    const updateScenes = () => {
+      const progress = progressRef?.current ?? 0
+      const sceneFloat = progress * 3
+      const activeScene = Math.min(Math.floor(sceneFloat), 2)
+      sceneIndexRef.current = activeScene
 
-    const runLoop = () => {
-      setTypedChars(0)
-      setResponseChars1(0)
-      setResponseChars2(0)
-      setShowMetrics(false)
+      sceneRefs.current.forEach((el, i) => {
+        if (!el) return
 
-      for (let i = 1; i <= PROMPT_TEXT.length; i++) {
-        schedule(() => setTypedChars(i), 500 + i * 40)
-      }
-
-      const promptDone = 500 + PROMPT_TEXT.length * 40 + 300
-      schedule(() => { if (onAction) onAction('model') }, promptDone)
-
-      for (let i = 1; i <= RESPONSE_V1.length; i++) {
-        schedule(() => setResponseChars1(i), promptDone + i * 20)
-      }
-      for (let i = 1; i <= RESPONSE_V2.length; i++) {
-        schedule(() => setResponseChars2(i), promptDone + 200 + i * 20)
-      }
-
-      const responseDone = promptDone + Math.max(RESPONSE_V1.length, RESPONSE_V2.length + 200) * 20 + 300
-      schedule(() => {
-        setShowMetrics(true)
-        if (onAction) onAction('perf')
-      }, responseDone)
-
-      schedule(() => { if (onAction) onAction('inbox') }, responseDone + 800)
-
-      schedule(runLoop, LOOP_DURATION)
+        if (i === activeScene) {
+          gsap.set(el, { opacity: 1, visibility: 'visible', zIndex: 2 })
+        } else {
+          const dist = Math.abs(i - sceneFloat)
+          const fade = Math.max(0, 1 - dist * 4)
+          if (fade > 0.01) {
+            gsap.set(el, { opacity: fade, visibility: 'visible', zIndex: 1 })
+          } else {
+            gsap.set(el, { opacity: 0, visibility: 'hidden', zIndex: 0 })
+          }
+        }
+      })
     }
 
-    runLoop()
-    loopRef.current = timers
-    return () => timers.forEach(clearTimeout)
-  }, [isActive, onAction])
+    gsap.ticker.add(updateScenes)
+    tickerRef.current = updateScenes
+
+    return () => {
+      gsap.ticker.remove(updateScenes)
+    }
+  }, [isActive, progressRef])
+
+  const progress = progressRef?.current ?? 0
+  const activeScene = Math.min(Math.floor(progress * 3), 2)
 
   return (
     <div className="w-full h-full flex bg-[#fafbfd] text-[10px] overflow-hidden">
-      <div className="w-12 bg-white border-r border-gray-100 flex flex-col items-center py-4 gap-4 shrink-0">
-        {sidebarIcons.map((Icon, i) => (
-          <div key={i} className="w-8 h-8 rounded-lg flex items-center justify-center" style={{ backgroundColor: i === 3 ? 'rgba(56, 89, 168, 0.1)' : 'transparent' }}>
-            <Icon className="w-4 h-4" strokeWidth={1.5} style={{ color: i === 3 ? '#3859a8' : '#a0a0a0' }} />
-          </div>
-        ))}
-      </div>
+      <Sidebar activeScene={activeScene} />
 
-      <div className="flex-1 flex flex-col p-3 min-w-0">
-        <div className="flex items-center justify-between mb-3">
-          <p className="text-xs font-semibold text-gray-900">AI Model Playground</p>
-          <div className="px-2 py-0.5 rounded-full text-[9px] font-medium text-white" style={{ backgroundColor: '#3859a8' }}>Compare</div>
+      <div className="flex-1 relative min-w-0">
+        <div
+          ref={(el) => { sceneRefs.current[0] = el }}
+          className="absolute inset-0 flex"
+        >
+          <ModelSelectionScene progress={progress} />
         </div>
 
-        {/* Prompt input */}
-        <div className="bg-white rounded-lg border border-gray-200 px-2.5 py-1.5 mb-3 text-[10px] text-gray-700 min-h-[28px]">
-          {PROMPT_TEXT.slice(0, typedChars)}
-          {typedChars < PROMPT_TEXT.length && typedChars > 0 && (
-            <span className="inline-block w-px h-3 bg-gray-800 ml-px animate-pulse" />
-          )}
-          {typedChars === 0 && <span className="text-gray-300">Type a prompt...</span>}
+        <div
+          ref={(el) => { sceneRefs.current[1] = el }}
+          className="absolute inset-0 flex"
+        >
+          <ChatScene />
         </div>
 
-        {/* Model comparison panels */}
-        <div className="flex gap-2 flex-1">
-          {[
-            { name: 'v2.1', response: RESPONSE_V1, chars: responseChars1, highlighted: false },
-            { name: 'v2.3', response: RESPONSE_V2, chars: responseChars2, highlighted: true },
-          ].map((model) => (
-            <div
-              key={model.name}
-              className="flex-1 rounded-lg border p-2 flex flex-col"
-              style={{
-                borderColor: model.highlighted ? 'rgba(56, 89, 168, 0.25)' : '#e5e7eb',
-                backgroundColor: model.highlighted ? 'rgba(56, 89, 168, 0.02)' : '#fff',
-              }}
-            >
-              <p className="text-[10px] font-semibold text-gray-900 mb-1.5">Receptionist {model.name}</p>
-              <p className="text-[9px] text-gray-600 leading-[1.4] flex-1">
-                {model.response.slice(0, model.chars)}
-                {model.chars > 0 && model.chars < model.response.length && (
-                  <span className="inline-block w-px h-2.5 bg-gray-400 ml-px animate-pulse" />
-                )}
-              </p>
-              <AnimatePresence>
-                {showMetrics && (
-                  <motion.div
-                    initial={{ opacity: 0 }}
-                    animate={{ opacity: 1 }}
-                    transition={{ duration: 0.3 }}
-                    className="mt-1.5 pt-1.5 border-t border-gray-100 text-[8px] text-gray-400"
-                  >
-                    Score: <span style={{ color: model.highlighted ? '#3859a8' : '#374151', fontWeight: 600 }}>{model.highlighted ? '94%' : '87%'}</span>
-                  </motion.div>
-                )}
-              </AnimatePresence>
-            </div>
-          ))}
+        <div
+          ref={(el) => { sceneRefs.current[2] = el }}
+          className="absolute inset-0 flex"
+        >
+          <AgentCreationScene progress={progress} />
         </div>
       </div>
     </div>

--- a/docs/superpowers/specs/2026-04-27-space-screen-redesign.md
+++ b/docs/superpowers/specs/2026-04-27-space-screen-redesign.md
@@ -1,0 +1,205 @@
+# SpaceScreen Redesign: Scroll-Driven 3-Scene Sequential Flow
+
+**Goal:** Replace the single auto-cycling model comparison view with a 3-scene sequential flow (model selection, chat exchange, agent creation) driven by GSAP ScrollTrigger.
+
+**Related:** GH issue #102, PR #101 (Messenger pattern reference)
+
+---
+
+## Architecture
+
+SpaceScreen follows the same scroll-driven pattern established by MessengerScreen:
+
+- Parent (ScrollProductShowcase) allocates 3x scroll range for the Space slide
+- A `spaceProgressRef` ref carries 0-1 progress from the parent GSAP proxy into the child
+- SpaceScreen reads progress on a GSAP ticker and determines which scene (0, 1, 2) is active
+- Scenes cross-fade via GSAP-set opacity on scene container divs
+
+### Progress-to-scene mapping
+
+| Progress range | Active scene | Description |
+|---|---|---|
+| 0.00 - 0.33 | Scene 1 | Model Selection |
+| 0.33 - 0.66 | Scene 2 | Chat Exchange |
+| 0.66 - 1.00 | Scene 3 | Agent Creation |
+
+Transitions use a small blend zone (~0.05 progress width) where the outgoing scene fades to 0 and incoming fades to 1.
+
+---
+
+## Scene 1: Model Selection
+
+A grid of 4 model cards inside the workspace content area. When progress enters scene 1, cards appear with staggered opacity. The third card (Claude) gets a selection highlight (border glow + checkmark) as progress moves through the scene.
+
+### Model cards
+
+| Model | Label | Color accent |
+|---|---|---|
+| GPT-4 | GPT-4 | #10a37f |
+| Claude | Claude | #d97706 |
+| Gemini | Gemini | #4285f4 |
+| Llama | Llama 3 | #7c3aed |
+
+Each card shows: model name, a small icon/dot in the accent color, and a one-line capability tag (e.g., "Fast reasoning", "Long context").
+
+The selected card (Claude) gets:
+- Border changes to accent color
+- Small checkmark badge in top-right corner
+- Subtle scale bump (1.02)
+
+### Layout
+
+```
++--+------------------------------------------+
+|  |  Select a Model                          |
+|  |                                          |
+|S |  [GPT-4]  [Claude]                       |
+|I |  [Gemini] [Llama 3]                      |
+|D |                                          |
+|E |                                          |
+|B |                                          |
+|A |                                          |
+|R |                                          |
++--+------------------------------------------+
+```
+
+---
+
+## Scene 2: Chat Exchange
+
+A chat interface showing a 3-message conversation between a user and "Claude" (the selected model). Messages are static (all visible at once, no typing animation -- consistent with Messenger's static approach for scroll-controlled screens).
+
+### Messages
+
+1. **User:** "Summarize today's missed calls and suggest follow-ups"
+2. **AI (Claude):** "You had 3 missed calls today. Two from returning clients asking about pricing -- I recommend a follow-up text with your rate sheet. One new lead from Google Ads -- I suggest an immediate callback, they're comparing providers."
+3. **User:** "Schedule the callback for 2 PM"
+
+### Action indicator
+
+Below the messages, a small action chip: calendar icon + "Callback scheduled, 2:00 PM" (same pattern as Messenger's action indicators).
+
+### Layout
+
+```
++--+------------------------------------------+
+|  |  Claude Chat                    [Online] |
+|  |                                          |
+|S |  [User bubble: Summarize...]             |
+|I |  [AI bubble: You had 3 missed...]        |
+|D |  [User bubble: Schedule...]              |
+|E |                                          |
+|B |  [Calendar icon] Callback scheduled      |
+|A |                                          |
+|R |  [Type a message...          ] [Send]    |
++--+------------------------------------------+
+```
+
+---
+
+## Scene 3: Agent Creation
+
+A simple creation flow showing the result of clicking "Create Agent". Three substates shown statically at different progress points within scene 3:
+
+- **Early (0.66-0.77):** A form-like card with agent name "Sales Assistant", model "Claude", purpose "Follow-up & scheduling". A blue "Create Agent" button.
+- **Mid (0.77-0.88):** Same card but button replaced with a spinner and "Creating..." text.
+- **Late (0.88-1.00):** Success state -- green checkmark, "Agent Created", agent name with "Active" status badge.
+
+### Layout
+
+```
++--+------------------------------------------+
+|  |  Create New Agent                        |
+|  |                                          |
+|S |  +------------------------------------+  |
+|I |  | Name: Sales Assistant              |  |
+|D |  | Model: Claude                      |  |
+|E |  | Purpose: Follow-up & scheduling    |  |
+|B |  |                                    |  |
+|A |  | [checkmark] Agent Created          |  |
+|R |  | Sales Assistant -- Active          |  |
+|  |  +------------------------------------+  |
++--+------------------------------------------+
+```
+
+---
+
+## Workspace Frame (persistent)
+
+The sidebar stays visible across all three scenes. Same 5-icon sidebar as current SpaceScreen but with the active icon changing per scene:
+
+| Scene | Active sidebar icon |
+|---|---|
+| Model Selection | Cpu |
+| Chat Exchange | MessageCircle |
+| Agent Creation | Users |
+
+The active icon gets the blue highlight background (`rgba(56, 89, 168, 0.1)`) and blue icon color.
+
+---
+
+## ScrollProductShowcase Changes
+
+### New constants
+
+```
+SPACE_INDEX = 3
+SPACE_SCENES = 3
+```
+
+### TOTAL_SCROLL update
+
+```js
+const TOTAL_SCROLL = PRODUCT_SLIDES.reduce((sum, _, i) => {
+  if (i === MESSENGER_INDEX) return sum + BASE_SCROLL * MESSENGER_CHANNELS
+  if (i === SPACE_INDEX) return sum + BASE_SCROLL * SPACE_SCENES
+  return sum + BASE_SCROLL
+}, 0)
+```
+
+### Timeline hold phase
+
+Same pattern as Messenger: variable hold duration with scene sub-labels and a progress proxy.
+
+```js
+if (i === SPACE_INDEX) {
+  const holdDur = 0.4 * SPACE_SCENES
+  const proxy = { progress: 0 }
+  tl.addLabel(`hold-${i}`)
+  for (let sc = 0; sc < SPACE_SCENES; sc++) {
+    tl.addLabel(`space-scene-${sc}`, `hold-${i}+=${(sc / SPACE_SCENES) * holdDur}`)
+  }
+  tl.to(proxy, {
+    progress: 1, duration: holdDur, ease: 'none',
+    onUpdate: () => { spaceProgressRef.current = proxy.progress },
+  })
+}
+```
+
+### Snap points
+
+Add `space-scene-0`, `space-scene-1`, `space-scene-2` to the snap array for the Space slide.
+
+### Props
+
+- Add `spaceProgressRef` to ScrollProductShowcase state
+- Pass through ProductSlide -> SlideDevice -> SpaceScreen as `progressRef`
+
+---
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `components/sections/showcase/screens/SpaceScreen.jsx` | Complete rewrite: 3 scene components, GSAP ticker, progress-driven scene switching |
+| `components/sections/ScrollProductShowcase.jsx` | Add SPACE_INDEX/SPACE_SCENES constants, update TOTAL_SCROLL, add timeline hold/snap/progress for Space |
+| `components/sections/showcase/ProductSlide.jsx` | Pass `spaceProgressRef` prop |
+| `components/sections/showcase/SlideDevice.jsx` | Pass `progressRef` to SpaceScreen |
+
+---
+
+## What this does NOT cover
+
+- Device reflections and laptop sizing (GH issue #103)
+- Mobile-specific Space animations
+- Floating card updates for Space slide


### PR DESCRIPTION
## Summary
- Replace timer-based model comparison with 3-scene sequential flow driven by GSAP ScrollTrigger
- **Scene 1**: Model selection grid (GPT-4, Claude, Gemini, Llama 3) with Claude getting selected
- **Scene 2**: Chat exchange with Claude showing missed call summary and callback scheduling
- **Scene 3**: Agent creation flow (form, spinner, success confirmation)
- Space slide gets 3x scroll range (3600px) with 3 snap points, same pattern as Messenger
- Persistent sidebar with active icon changing per scene

## Test plan
- [ ] Scroll to Space slide, verify Scene 1 shows model cards with Claude selected
- [ ] Scroll through Scene 2, verify chat with action indicator (callback scheduled)
- [ ] Scroll through Scene 3, verify form -> spinner -> success transition
- [ ] Verify snap points work for each scene
- [ ] Verify sidebar active icon changes per scene
- [ ] Verify other slides (Receptionist, Messenger, Outreach, Avatar) unaffected
- [ ] Test mobile layout
- [ ] Build passes

Closes #102