### PR TITLE
feat(showcase): rebuild product slide animations with continuous loops

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -741,6 +741,17 @@ textarea:focus-visible {
   100% { transform: scale(0.5); opacity: 0; }
 }
 
+@keyframes caret-blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+@keyframes sent-bubble-in {
+  0% { transform: translateY(8px) scale(0.9); opacity: 0; }
+  60% { transform: translateY(-1px) scale(1.02); opacity: 1; }
+  100% { transform: translateY(0) scale(1); opacity: 1; }
+}
+
 .animate-phone-vibrate {
   animation: phone-vibrate 0.6s ease-in-out 3;
 }

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,5 +1,5 @@
 import { Hero } from '@/components/sections/Hero'
-import { LogoCloud } from '@/components/sections/LogoCloud'
+// import { LogoCloud } from '@/components/sections/LogoCloud'
 import { ScrollProductShowcase } from '@/components/sections/ScrollProductShowcase'
 import { HowItWorks } from '@/components/sections/HowItWorks'
 import { Stats } from '@/components/sections/Stats'
@@ -17,7 +17,7 @@ export default function Home() {
   return (
     <>
       <Hero />
-      <LogoCloud />
+      {/* <LogoCloud /> */}
       <ScrollProductShowcase />
       <HowItWorks />
       <Stats />

--- a/components/sections/ScrollProductShowcase.jsx
+++ b/components/sections/ScrollProductShowcase.jsx
@@ -14,7 +14,7 @@ gsap.registerPlugin(useGSAP, ScrollTrigger)
 const MESSENGER_INDEX = 1
 const MESSENGER_CHANNELS = 4
 const SPACE_INDEX = 3
-const SPACE_SCENES = 3
+const SPACE_SCENES = 1
 const BASE_SCROLL = 1200
 const TOTAL_SCROLL = PRODUCT_SLIDES.reduce((sum, _, i) => {
   if (i === MESSENGER_INDEX) return sum + BASE_SCROLL * MESSENGER_CHANNELS

--- a/components/sections/Stats.jsx
+++ b/components/sections/Stats.jsx
@@ -42,7 +42,7 @@ const STATS = [
 
 export function Stats() {
   return (
-    <section className="surface-navy py-20">
+    <section className="py-20">
       <div className="max-w-7xl mx-auto px-6">
 
         {/* Optional section label */}
@@ -50,7 +50,7 @@ export function Stats() {
           <p
             className="text-[11px] font-semibold tracking-[0.14em] uppercase"
             style={{
-              color: 'rgba(255, 255, 255, 0.6)',
+              color: '#3859a8',
               fontFamily: 'var(--font-display)',
             }}
           >
@@ -79,23 +79,23 @@ function StatCard({ stat }) {
     <div
       className="rounded-[20px] p-5 sm:p-7 flex flex-col gap-3 sm:gap-4 transition-all duration-300"
       style={{
-        background: 'rgba(255,255,255,0.12)',
-        backdropFilter: 'blur(16px) saturate(1.5)',
-        WebkitBackdropFilter: 'blur(16px) saturate(1.5)',
-        border: '1px solid rgba(255,255,255,0.18)',
-        boxShadow: 'inset 0 1px 0 rgba(255,255,255,0.10)',
+        background: 'rgba(255,255,255,0.7)',
+        backdropFilter: 'blur(16px) saturate(1.4)',
+        WebkitBackdropFilter: 'blur(16px) saturate(1.4)',
+        border: '1px solid rgba(56, 89, 168, 0.10)',
+        boxShadow: '0 4px 20px rgba(15, 17, 41, 0.04), inset 0 1px 0 rgba(255,255,255,0.8)',
       }}
       onMouseEnter={e => {
         e.currentTarget.style.transform = 'translateY(-3px)'
-        e.currentTarget.style.boxShadow = `0 16px 48px rgba(0,0,0,0.2), inset 0 1px 0 rgba(255,255,255,0.15)`
-        e.currentTarget.style.borderColor = `rgba(255,255,255,0.28)`
-        e.currentTarget.style.background = 'rgba(255,255,255,0.16)'
+        e.currentTarget.style.boxShadow = '0 16px 48px rgba(15, 17, 41, 0.08), inset 0 1px 0 rgba(255,255,255,0.9)'
+        e.currentTarget.style.borderColor = 'rgba(56, 89, 168, 0.18)'
+        e.currentTarget.style.background = 'rgba(255,255,255,0.85)'
       }}
       onMouseLeave={e => {
         e.currentTarget.style.transform = 'translateY(0)'
-        e.currentTarget.style.boxShadow = 'inset 0 1px 0 rgba(255,255,255,0.10)'
-        e.currentTarget.style.borderColor = 'rgba(255,255,255,0.18)'
-        e.currentTarget.style.background = 'rgba(255,255,255,0.12)'
+        e.currentTarget.style.boxShadow = '0 4px 20px rgba(15, 17, 41, 0.04), inset 0 1px 0 rgba(255,255,255,0.8)'
+        e.currentTarget.style.borderColor = 'rgba(56, 89, 168, 0.10)'
+        e.currentTarget.style.background = 'rgba(255,255,255,0.7)'
       }}
     >
       {/* Icon */}

--- a/components/sections/showcase/SlideDevice.jsx
+++ b/components/sections/showcase/SlideDevice.jsx
@@ -4,7 +4,6 @@ import { useState, useCallback, useRef } from 'react'
 import { PhoneMockup } from './devices/PhoneMockup'
 import { LaptopMockup } from './devices/LaptopMockup'
 import { MonitorMockup } from './devices/MonitorMockup'
-import { FloatingCards } from './cards/FloatingCards'
 import { ReceptionistScreen } from './screens/ReceptionistScreen'
 import { MessengerScreen } from './screens/MessengerScreen'
 import { OutreachScreen } from './screens/OutreachScreen'
@@ -68,8 +67,6 @@ export function SlideDevice({ slug, deviceType, isActive, messengerProgressRef, 
           transform: TILT[deviceType],
         }}
       >
-        <FloatingCards slug={slug} highlightedCards={highlightedCards} />
-
         <div className="relative" style={{ transform: 'translateZ(0px)' }}>
           {isMessenger ? (
             <div className="relative" style={{ width: 320, height: 660 }}>

--- a/components/sections/showcase/screens/MessengerScreen.jsx
+++ b/components/sections/showcase/screens/MessengerScreen.jsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useRef, useEffect } from 'react'
+import { useRef, useEffect, useState } from 'react'
 import gsap from 'gsap'
 import { Calendar, Bell, Ticket, Send, MessageSquare, Globe, MessageCircle, Users } from 'lucide-react'
 import Logo from '@/components/ui/Logo'
@@ -44,6 +44,7 @@ const CONVERSATIONS = [
     messages: [
       { role: 'user', text: 'Can you create a support ticket for the billing issue?' },
       { role: 'ai', text: "I'll create that with all conversation details." },
+      { role: 'user', text: 'Please mark it high priority.' },
     ],
     action: { icon: Ticket, label: 'Ticket created', sublabel: 'Added to CRM' },
     finalMsg: 'Ticket #4821 assigned to your account manager.',
@@ -61,9 +62,70 @@ function lerp(a, b, t) {
   return a + (b - a) * t
 }
 
-function ChannelCard({ channel, conversation }) {
+function ChannelCard({ channel, conversation, isActive }) {
   const Icon = channel.icon
   const ActionIcon = conversation.action.icon
+  const [phase, setPhase] = useState('idle')
+  const [typedText, setTypedText] = useState('')
+  const [showSentMsg, setShowSentMsg] = useState(false)
+  const [sendPulse, setSendPulse] = useState(false)
+  const scrollRef = useRef(null)
+
+  useEffect(() => {
+    if (!isActive) {
+      setPhase('idle')
+      setTypedText('')
+      setShowSentMsg(false)
+      setSendPulse(false)
+      return
+    }
+
+    let timers = []
+    const t = (fn, ms) => { const id = setTimeout(fn, ms); timers.push(id); return id }
+
+    const runCycle = () => {
+      setPhase('thinking')
+      setTypedText('')
+      setSendPulse(false)
+
+      t(() => {
+        setPhase('typing')
+        const message = conversation.finalMsg
+        const typeSpeed = 32
+        message.split('').forEach((_, i) => {
+          t(() => setTypedText(message.slice(0, i + 1)), i * typeSpeed)
+        })
+        const totalType = message.length * typeSpeed
+
+        t(() => {
+          setSendPulse(true)
+          t(() => setSendPulse(false), 280)
+        }, totalType + 280)
+
+        t(() => {
+          setShowSentMsg(true)
+          setTypedText('')
+          setPhase('thinking')
+        }, totalType + 600)
+
+        t(() => {
+          setShowSentMsg(false)
+          runCycle()
+        }, totalType + 2200)
+      }, 800)
+    }
+
+    const startId = setTimeout(runCycle, 200)
+    timers.push(startId)
+
+    return () => timers.forEach(clearTimeout)
+  }, [isActive, conversation.finalMsg])
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [showSentMsg, phase])
 
   return (
     <div className="w-full h-full flex flex-col bg-white overflow-hidden" style={{ borderRadius: 30 }}>
@@ -87,11 +149,11 @@ function ChannelCard({ channel, conversation }) {
         </div>
       </div>
 
-      <div className="flex-1 px-3 py-2 overflow-hidden">
+      <div ref={scrollRef} className="flex-1 px-3 py-2 overflow-hidden">
         {conversation.messages.map((msg, i) => (
           <div
             key={i}
-            className={`flex mb-1.5 ${msg.role === 'user' ? 'justify-end' : 'items-end gap-1.5'}`}
+            className={`flex mb-3 ${msg.role === 'user' ? 'justify-end' : 'items-end gap-1.5'}`}
           >
             {msg.role === 'ai' && (
               <div
@@ -104,10 +166,10 @@ function ChannelCard({ channel, conversation }) {
             <div
               className={`max-w-[78%] px-2.5 py-1.5 text-[10px] leading-[1.4] ${
                 msg.role === 'user'
-                  ? 'rounded-xl rounded-br-sm text-white'
-                  : 'rounded-xl rounded-bl-sm text-gray-900'
+                  ? 'rounded-xl rounded-br-sm text-gray-900'
+                  : 'rounded-xl rounded-bl-sm text-white'
               }`}
-              style={{ backgroundColor: msg.role === 'user' ? channel.color : '#f1f3f5' }}
+              style={{ backgroundColor: msg.role === 'user' ? '#f1f3f5' : channel.color }}
             >
               {msg.text}
             </div>
@@ -130,54 +192,91 @@ function ChannelCard({ channel, conversation }) {
           </div>
         </div>
 
-        <div className="flex items-end gap-1.5 mb-1.5">
+        {showSentMsg && (
           <div
-            className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
-            style={{ background: 'linear-gradient(135deg, #4a6fc2, #3859a8)' }}
+            className="flex items-end gap-1.5 mb-3"
+            style={{ animation: 'sent-bubble-in 0.45s ease-out' }}
           >
-            <Logo size={9} tone="on-dark" animate={false} />
+            <div
+              className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
+              style={{ background: 'linear-gradient(135deg, #4a6fc2, #3859a8)' }}
+            >
+              <Logo size={9} tone="on-dark" animate={false} />
+            </div>
+            <div
+              className="max-w-[78%] px-2.5 py-1.5 text-[10px] leading-[1.4] rounded-xl rounded-bl-sm text-white"
+              style={{ backgroundColor: channel.color }}
+            >
+              {conversation.finalMsg}
+            </div>
           </div>
-          <div className="max-w-[78%] px-2.5 py-1.5 text-[10px] leading-[1.4] rounded-xl rounded-bl-sm text-gray-900 bg-[#f1f3f5]">
-            {conversation.finalMsg}
-          </div>
-        </div>
-
-        <div className="flex items-end gap-1.5">
-          <div
-            className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
-            style={{ background: 'linear-gradient(135deg, #4a6fc2, #3859a8)' }}
-          >
-            <Logo size={9} tone="on-dark" animate={false} />
-          </div>
-          <div className="flex items-center gap-[3px] px-2.5 py-2 rounded-xl rounded-bl-sm bg-[#f1f3f5]">
-            {[0, 1, 2].map((dot) => (
-              <div
-                key={dot}
-                className="w-[5px] h-[5px] rounded-full"
-                style={{
-                  backgroundColor: channel.color,
-                  opacity: 0.5,
-                  animation: `typing-dot 1.4s ease-in-out ${dot * 0.2}s infinite`,
-                }}
-              />
-            ))}
-          </div>
-        </div>
+        )}
       </div>
 
       <div className="shrink-0 px-3 py-2 border-t border-gray-100 flex items-center gap-2">
+        <div className="relative shrink-0" style={{ width: 24, height: 24 }}>
+          {phase === 'thinking' && [0, 1, 2].map((i) => (
+            <span
+              key={i}
+              className="absolute rounded-full"
+              style={{
+                width: 24, height: 24,
+                top: 0, left: 0,
+                border: `1.5px solid ${channel.color}`,
+                opacity: 0.35 - i * 0.08,
+                animation: `ring-expand 1.4s ease-out ${i * 0.35}s infinite`,
+              }}
+            />
+          ))}
+          <div
+            className="w-6 h-6 rounded-full flex items-center justify-center relative"
+            style={{
+              background: `linear-gradient(135deg, ${channel.color}, ${channel.color}cc)`,
+              animation: phase === 'thinking' ? 'orb-pulse 1.2s ease-in-out infinite' : 'none',
+            }}
+          >
+            <Logo size={10} tone="on-dark" animate={false} />
+          </div>
+        </div>
+        <div className="flex-1 bg-gray-50 rounded-full px-3 py-1 text-[9px] flex items-center min-h-5">
+          {phase === 'thinking' ? (
+            <span className="flex items-center gap-0.75">
+              {[0, 1, 2].map((d) => (
+                <span
+                  key={d}
+                  className="w-1 h-1 rounded-full"
+                  style={{
+                    backgroundColor: channel.color,
+                    opacity: 0.6,
+                    animation: `typing-dot 1.4s ease-in-out ${d * 0.2}s infinite`,
+                  }}
+                />
+              ))}
+            </span>
+          ) : phase === 'typing' ? (
+            <span className="text-gray-800">
+              {typedText}
+              <span
+                className="inline-block w-px ml-px align-middle"
+                style={{
+                  height: 9,
+                  backgroundColor: channel.color,
+                  animation: 'caret-blink 0.8s step-end infinite',
+                }}
+              />
+            </span>
+          ) : (
+            <span className="text-gray-400">Type a message...</span>
+          )}
+        </div>
         <div
           className="w-6 h-6 rounded-full flex items-center justify-center shrink-0"
-          style={{ background: `linear-gradient(135deg, ${channel.color}, ${channel.color}cc)` }}
-        >
-          <Logo size={10} tone="on-dark" animate={false} />
-        </div>
-        <div className="flex-1 bg-gray-50 rounded-full px-3 py-1 text-[9px] text-gray-400">
-          Type a message...
-        </div>
-        <div
-          className="w-6 h-6 rounded-full flex items-center justify-center shrink-0"
-          style={{ backgroundColor: channel.color }}
+          style={{
+            backgroundColor: channel.color,
+            transform: sendPulse ? 'scale(1.18)' : 'scale(1)',
+            boxShadow: sendPulse ? `0 0 0 4px ${channel.color}33` : 'none',
+            transition: 'transform 0.2s ease-out, box-shadow 0.2s ease-out',
+          }}
         >
           <Send className="w-3 h-3 text-white" strokeWidth={1.5} />
         </div>
@@ -260,7 +359,7 @@ export function MessengerScreen({ isActive, onAction, progressRef }) {
             overflow: 'hidden',
           }}
         >
-          <ChannelCard channel={ch} conversation={CONVERSATIONS[i]} />
+          <ChannelCard channel={ch} conversation={CONVERSATIONS[i]} isActive={isActive} />
         </div>
       ))}
     </div>

--- a/components/sections/showcase/screens/OutreachScreen.jsx
+++ b/components/sections/showcase/screens/OutreachScreen.jsx
@@ -2,42 +2,129 @@
 
 import { useState, useEffect, useRef } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { Phone, MessageCircle, Mail, PhoneOff } from 'lucide-react'
+import { FileSpreadsheet, Phone, MessageCircle, Mail, Check, Upload } from 'lucide-react'
 
-const stats = [
+const CONTACTS_TOTAL = 247
+
+const CHANNELS = [
+  { id: 'call', icon: Phone, label: 'Calling leads', color: '#3859a8', cardId: 'dialer' },
+  { id: 'sms', icon: MessageCircle, label: 'Sending SMS', color: '#22D3EE', cardId: 'dialer' },
+  { id: 'email', icon: Mail, label: 'Sending emails', color: '#6366F1', cardId: 'email' },
+]
+
+const FINAL_STATS = [
   { label: 'Contacted', target: 247 },
   { label: 'Reached', target: 68, suffix: '%' },
   { label: 'Booked', target: 34 },
 ]
 
-const activityFeed = [
-  { icon: Phone, name: 'John D.', action: 'Booked meeting', cardId: 'dialer' },
-  { icon: MessageCircle, name: 'Lisa R.', action: 'Replied interested', cardId: 'dialer' },
-  { icon: Mail, name: 'Mark T.', action: 'Email opened', cardId: 'email' },
-  { icon: PhoneOff, name: 'Ana R.', action: 'Voicemail left', cardId: 'dialer' },
-]
+const PHASE_TIMES = {
+  uploadStart: 300,
+  uploadDuration: 1800,
+  parsed: 2500,
+  channelStart: 3300,
+  channelDuration: 1700,
+  finalStats: 9300,
+  loop: 12000,
+}
 
-const LOOP_DURATION = 10000
+function ProgressBar({ progress, color }) {
+  return (
+    <div className="w-full h-1 rounded-full bg-gray-100 overflow-hidden">
+      <div
+        className="h-full rounded-full transition-[width] duration-[60ms] ease-linear"
+        style={{ width: `${progress * 100}%`, backgroundColor: color }}
+      />
+    </div>
+  )
+}
 
-function AnimatedStat({ label, target, suffix = '', progress }) {
+function ChannelRow({ channel, state, count }) {
+  const Icon = channel.icon
+  const isActive = state === 'active'
+  const isDone = state === 'done'
+  const progress = isDone ? 1 : isActive ? Math.min(count / CONTACTS_TOTAL, 1) : 0
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: state === 'pending' ? 0.4 : 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+      className="flex items-center gap-2.5 py-2 px-2.5 rounded-xl"
+      style={{
+        backgroundColor: isActive ? `${channel.color}10` : '#f8f9fb',
+        border: `1px solid ${isActive ? `${channel.color}30` : 'transparent'}`,
+        transition: 'background-color 0.3s, border-color 0.3s',
+      }}
+    >
+      <div
+        className="w-8 h-8 rounded-lg flex items-center justify-center shrink-0 relative"
+        style={{
+          backgroundColor: isActive || isDone ? `${channel.color}18` : 'rgba(0,0,0,0.04)',
+          transition: 'background-color 0.3s',
+        }}
+      >
+        {isActive && (
+          <span
+            className="absolute inset-0 rounded-lg"
+            style={{
+              border: `1.5px solid ${channel.color}`,
+              animation: 'ring-expand 1.4s ease-out infinite',
+              opacity: 0.4,
+            }}
+          />
+        )}
+        <Icon className="w-4 h-4" style={{ color: isActive || isDone ? channel.color : '#9ca3af' }} strokeWidth={1.6} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center justify-between mb-1">
+          <p className="text-[10.5px] font-semibold text-gray-900">{channel.label}</p>
+          <p className="text-[10px] font-mono tabular-nums" style={{ color: isActive || isDone ? channel.color : '#9ca3af' }}>
+            {Math.floor(progress * CONTACTS_TOTAL)}/{CONTACTS_TOTAL}
+          </p>
+        </div>
+        <ProgressBar progress={progress} color={channel.color} />
+      </div>
+      {isDone && (
+        <motion.div
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ type: 'spring', stiffness: 400, damping: 18 }}
+          className="w-4 h-4 rounded-full flex items-center justify-center shrink-0"
+          style={{ backgroundColor: '#22c55e' }}
+        >
+          <Check className="w-2.5 h-2.5 text-white" strokeWidth={3} />
+        </motion.div>
+      )}
+    </motion.div>
+  )
+}
+
+function FinalStatCard({ label, target, suffix = '', progress }) {
   const value = Math.min(Math.floor(target * progress), target)
   return (
-    <div className="flex-1 rounded-lg border border-gray-100 px-2 py-2 text-center">
-      <p className="text-base font-bold" style={{ color: '#3859a8' }}>{value}{suffix}</p>
-      <p className="text-[9px] text-gray-400 mt-0.5">{label}</p>
+    <div className="flex-1 rounded-lg border border-gray-100 bg-white px-2 py-2 text-center">
+      <p className="text-[15px] font-bold tabular-nums" style={{ color: '#3859a8' }}>{value}{suffix}</p>
+      <p className="text-[8.5px] text-gray-400 mt-0.5">{label}</p>
     </div>
   )
 }
 
 export function OutreachScreen({ isActive, onAction }) {
-  const [visibleItems, setVisibleItems] = useState(0)
-  const [statProgress, setStatProgress] = useState(0)
+  const [phase, setPhase] = useState('idle')
+  const [uploadProgress, setUploadProgress] = useState(0)
+  const [channelStates, setChannelStates] = useState(['pending', 'pending', 'pending'])
+  const [channelCounts, setChannelCounts] = useState([0, 0, 0])
+  const [finalStatsProgress, setFinalStatsProgress] = useState(0)
   const loopRef = useRef(null)
 
   useEffect(() => {
     if (!isActive) {
-      setVisibleItems(0)
-      setStatProgress(0)
+      setPhase('idle')
+      setUploadProgress(0)
+      setChannelStates(['pending', 'pending', 'pending'])
+      setChannelCounts([0, 0, 0])
+      setFinalStatsProgress(0)
       if (loopRef.current) loopRef.current.forEach(clearTimeout)
       return
     }
@@ -46,23 +133,64 @@ export function OutreachScreen({ isActive, onAction }) {
     const schedule = (fn, ms) => { const id = setTimeout(fn, ms); timers.push(id); return id }
 
     const runLoop = () => {
-      setVisibleItems(0)
-      setStatProgress(0)
+      setPhase('idle')
+      setUploadProgress(0)
+      setChannelStates(['pending', 'pending', 'pending'])
+      setChannelCounts([0, 0, 0])
+      setFinalStatsProgress(0)
 
-      for (let step = 1; step <= 20; step++) {
-        schedule(() => setStatProgress(step / 20), 400 + step * 60)
+      schedule(() => setPhase('upload'), PHASE_TIMES.uploadStart)
+
+      const uploadSteps = 30
+      for (let i = 0; i <= uploadSteps; i++) {
+        schedule(() => setUploadProgress(i / uploadSteps), PHASE_TIMES.uploadStart + (i / uploadSteps) * PHASE_TIMES.uploadDuration)
       }
 
-      activityFeed.forEach((item, i) => {
+      schedule(() => setPhase('parsed'), PHASE_TIMES.parsed)
+      schedule(() => setPhase('channels'), PHASE_TIMES.channelStart)
+
+      CHANNELS.forEach((ch, idx) => {
+        const start = PHASE_TIMES.channelStart + idx * PHASE_TIMES.channelDuration
         schedule(() => {
-          setVisibleItems(i + 1)
-          if (onAction) onAction(item.cardId)
-        }, 2000 + i * 1200)
+          setChannelStates((prev) => {
+            const next = [...prev]
+            next[idx] = 'active'
+            return next
+          })
+          if (onAction) onAction(ch.cardId)
+        }, start)
+
+        const countSteps = 24
+        for (let s = 1; s <= countSteps; s++) {
+          schedule(() => {
+            setChannelCounts((prev) => {
+              const next = [...prev]
+              next[idx] = Math.floor(CONTACTS_TOTAL * (s / countSteps))
+              return next
+            })
+          }, start + (s / countSteps) * (PHASE_TIMES.channelDuration - 200))
+        }
+
+        schedule(() => {
+          setChannelStates((prev) => {
+            const next = [...prev]
+            next[idx] = 'done'
+            return next
+          })
+        }, start + PHASE_TIMES.channelDuration - 100)
       })
 
-      schedule(() => { if (onAction) onAction('analytics') }, 7500)
+      schedule(() => {
+        setPhase('summary')
+        if (onAction) onAction('analytics')
+      }, PHASE_TIMES.finalStats)
 
-      schedule(runLoop, LOOP_DURATION)
+      const statSteps = 24
+      for (let s = 1; s <= statSteps; s++) {
+        schedule(() => setFinalStatsProgress(s / statSteps), PHASE_TIMES.finalStats + 200 + (s / statSteps) * 1400)
+      }
+
+      schedule(runLoop, PHASE_TIMES.loop)
     }
 
     runLoop()
@@ -77,41 +205,146 @@ export function OutreachScreen({ isActive, onAction }) {
           <span className="w-2 h-2 rounded-full bg-green-500 animate-pulse" />
           <p className="font-semibold text-xs text-gray-900">Campaign: Spring Launch</p>
         </div>
-        <p className="text-[10px] text-gray-400">Running since 9:00 AM</p>
+        <p className="text-[10px] text-gray-400">AI-powered multi-channel outreach</p>
       </div>
 
-      <div className="flex gap-2 px-3 py-3 shrink-0">
-        {stats.map((stat) => (
-          <AnimatedStat key={stat.label} {...stat} progress={statProgress} />
-        ))}
-      </div>
+      <div className="flex-1 px-3 py-3 overflow-hidden flex flex-col gap-3">
+        {/* Upload card */}
+        <AnimatePresence mode="wait">
+          {(phase === 'idle' || phase === 'upload') && (
+            <motion.div
+              key="upload"
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, y: -10, scale: 0.96 }}
+              transition={{ duration: 0.35 }}
+              className="rounded-xl p-4 flex flex-col items-center gap-3"
+              style={{
+                background: 'linear-gradient(160deg, rgba(56,89,168,0.04), rgba(56,89,168,0.08))',
+                border: '1.5px dashed rgba(56,89,168,0.25)',
+              }}
+            >
+              <div
+                className="w-12 h-12 rounded-xl flex items-center justify-center relative"
+                style={{
+                  backgroundColor: '#fff',
+                  boxShadow: '0 4px 16px rgba(56,89,168,0.12)',
+                  border: '1px solid rgba(56,89,168,0.1)',
+                }}
+              >
+                {phase === 'upload' && (
+                  <>
+                    <span
+                      className="absolute inset-0 rounded-xl"
+                      style={{
+                        border: '1.5px solid rgba(56,89,168,0.4)',
+                        animation: 'ring-expand 1.5s ease-out infinite',
+                      }}
+                    />
+                    <span
+                      className="absolute inset-0 rounded-xl"
+                      style={{
+                        border: '1.5px solid rgba(56,89,168,0.25)',
+                        animation: 'ring-expand 1.5s ease-out 0.5s infinite',
+                      }}
+                    />
+                  </>
+                )}
+                <FileSpreadsheet className="w-6 h-6" style={{ color: '#3859a8' }} strokeWidth={1.5} />
+              </div>
 
-      <div className="px-3 flex-1 overflow-hidden">
-        <p className="text-[10px] font-semibold text-gray-400 uppercase tracking-wider mb-2">Recent Activity</p>
-        <div className="space-y-1.5">
-          <AnimatePresence>
-            {activityFeed.slice(0, visibleItems).map((item, i) => {
-              const Icon = item.icon
-              return (
-                <motion.div
-                  key={i}
-                  initial={{ opacity: 0, x: -16 }}
-                  animate={{ opacity: 1, x: 0 }}
-                  transition={{ duration: 0.3, ease: 'easeOut' }}
-                  className="flex items-center gap-2 py-1.5 px-2 rounded-lg bg-gray-50/80"
-                >
-                  <div className="w-7 h-7 rounded-lg flex items-center justify-center shrink-0" style={{ backgroundColor: 'rgba(56, 89, 168, 0.08)' }}>
-                    <Icon className="w-3.5 h-3.5" style={{ color: '#3859a8' }} strokeWidth={1.5} />
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="text-[10.5px] font-semibold text-gray-900 truncate">{item.name}</p>
-                    <p className="text-[9px] text-gray-400 truncate">{item.action}</p>
-                  </div>
-                </motion.div>
-              )
-            })}
-          </AnimatePresence>
-        </div>
+              <div className="text-center">
+                <p className="text-[11px] font-semibold text-gray-900">leads_q2.xlsx</p>
+                <p className="text-[9px] text-gray-400 mt-0.5">{CONTACTS_TOTAL} contacts</p>
+              </div>
+
+              <div className="w-full">
+                <div className="flex items-center gap-1 mb-1.5">
+                  <Upload className="w-2.5 h-2.5" style={{ color: '#3859a8' }} strokeWidth={1.8} />
+                  <p className="text-[9px] font-semibold" style={{ color: '#3859a8' }}>
+                    {phase === 'idle' ? 'Ready to upload' : `Importing... ${Math.round(uploadProgress * 100)}%`}
+                  </p>
+                </div>
+                <ProgressBar progress={uploadProgress} color="#3859a8" />
+              </div>
+            </motion.div>
+          )}
+
+          {phase === 'parsed' && (
+            <motion.div
+              key="parsed"
+              initial={{ opacity: 0, scale: 0.92 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, y: -10 }}
+              transition={{ duration: 0.4 }}
+              className="rounded-xl p-4 flex items-center gap-3"
+              style={{
+                background: 'linear-gradient(135deg, rgba(34,197,94,0.06), rgba(34,197,94,0.12))',
+                border: '1px solid rgba(34,197,94,0.2)',
+              }}
+            >
+              <motion.div
+                initial={{ scale: 0, rotate: -90 }}
+                animate={{ scale: 1, rotate: 0 }}
+                transition={{ type: 'spring', stiffness: 400, damping: 18 }}
+                className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
+                style={{ backgroundColor: '#22c55e' }}
+              >
+                <Check className="w-5 h-5 text-white" strokeWidth={3} />
+              </motion.div>
+              <div className="flex-1">
+                <p className="text-[11px] font-semibold text-gray-900">{CONTACTS_TOTAL} contacts imported</p>
+                <p className="text-[9px] text-gray-400 mt-0.5">Ready for outreach</p>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        {/* Channels sequence */}
+        {(phase === 'channels' || phase === 'summary') && (
+          <motion.div
+            key="channels"
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.35 }}
+            className="flex flex-col gap-1.5"
+          >
+            <p className="text-[9px] font-semibold text-gray-400 uppercase tracking-wider mb-0.5 px-1">
+              Outreach in progress
+            </p>
+            {CHANNELS.map((ch, i) => (
+              <ChannelRow
+                key={ch.id}
+                channel={ch}
+                state={channelStates[i]}
+                count={channelCounts[i]}
+              />
+            ))}
+          </motion.div>
+        )}
+
+        {/* Final stats */}
+        <AnimatePresence>
+          {phase === 'summary' && (
+            <motion.div
+              key="summary"
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.4, delay: 0.1 }}
+              className="mt-auto"
+            >
+              <p className="text-[9px] font-semibold text-gray-400 uppercase tracking-wider mb-1.5 px-1">
+                Campaign results
+              </p>
+              <div className="flex gap-1.5">
+                {FINAL_STATS.map((stat) => (
+                  <FinalStatCard key={stat.label} {...stat} progress={finalStatsProgress} />
+                ))}
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     </div>
   )

--- a/components/sections/showcase/screens/ReceptionistScreen.jsx
+++ b/components/sections/showcase/screens/ReceptionistScreen.jsx
@@ -126,7 +126,7 @@ function RingingPhase() {
 
 function AiOrb() {
   return (
-    <div className="flex justify-start mb-1.5">
+    <div className="flex justify-start mb-3">
       <div className="flex items-center gap-1.5">
         <div
           className="w-8 h-8 rounded-full flex items-center justify-center shrink-0"
@@ -157,7 +157,7 @@ function AiOrb() {
 
 function CallerWave() {
   return (
-    <div className="flex justify-end mb-1.5">
+    <div className="flex justify-end mb-3">
       <div className="flex items-center gap-[2px] px-2.5 py-1.5 rounded-xl rounded-br-sm" style={{ backgroundColor: '#3859a8' }}>
         {Array.from({ length: 5 }).map((_, i) => (
           <div
@@ -235,13 +235,13 @@ function ChatBubble({ line }) {
       initial={{ opacity: 0, y: 6 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.25, ease: 'easeOut' }}
-      className={`flex mb-1.5 ${isAI ? 'justify-start' : 'justify-end'}`}
+      className={`flex mb-3 ${isAI ? 'justify-start' : 'justify-end'}`}
     >
       <div
         className={`max-w-[82%] px-2.5 py-1.5 text-[10px] leading-[1.4] ${
-          isAI ? 'rounded-xl rounded-bl-sm bg-[#f1f3f5] text-gray-900' : 'rounded-xl rounded-br-sm text-white'
+          isAI ? 'rounded-xl rounded-bl-sm text-white' : 'rounded-xl rounded-br-sm bg-[#f1f3f5] text-gray-900'
         }`}
-        style={isAI ? {} : { backgroundColor: '#3859a8' }}
+        style={isAI ? { backgroundColor: '#3859a8' } : {}}
       >
         {line.text}
       </div>

--- a/components/sections/showcase/screens/SpaceScreen.jsx
+++ b/components/sections/showcase/screens/SpaceScreen.jsx
@@ -1,288 +1,356 @@
 'use client'
 
-import { useRef, useEffect } from 'react'
-import gsap from 'gsap'
-import { MessageCircle, Users, BarChart3, Cpu, Settings, Check, Calendar, Loader2 } from 'lucide-react'
+import { useState, useEffect, useRef } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import { Send, ChevronDown, Check, Paperclip, Mic } from 'lucide-react'
 import Logo from '@/components/ui/Logo'
 
-const SIDEBAR_ICONS = [MessageCircle, Users, BarChart3, Cpu, Settings]
-
-const SCENE_SIDEBAR_ACTIVE = [3, 0, 1]
-
 const MODELS = [
-  { name: 'GPT-4', tag: 'Fast reasoning', color: '#10a37f' },
-  { name: 'Claude', tag: 'Long context', color: '#d97706' },
-  { name: 'Gemini', tag: 'Multimodal', color: '#4285f4' },
-  { name: 'Llama 3', tag: 'Open source', color: '#7c3aed' },
+  { name: 'GPT-4o', provider: 'OpenAI', color: '#10a37f' },
+  { name: 'Claude 4.7', provider: 'Anthropic', color: '#d97706' },
+  { name: 'Gemini 2.5', provider: 'Google', color: '#4285f4' },
+  { name: 'Llama 3', provider: 'Meta', color: '#7c3aed' },
 ]
 
-const SELECTED_MODEL = 1
+const PROMPT_TEXT = "Summarize today's missed calls"
+const RESPONSE_TEXT = 'You had 3 missed calls today. Two from returning clients asking about pricing — I can send the rate sheet. One new lead from Google Ads — I recommend an immediate callback.'
 
-const CHAT_MESSAGES = [
-  { role: 'user', text: 'Summarize today\'s missed calls and suggest follow-ups' },
-  { role: 'ai', text: 'You had 3 missed calls today. Two from returning clients asking about pricing. I recommend a follow-up text with your rate sheet. One new lead from Google Ads. I suggest an immediate callback.' },
-  { role: 'user', text: 'Schedule the callback for 2 PM' },
-]
+export function SpaceScreen({ isActive, onAction }) {
+  const [phase, setPhase] = useState('idle')
+  const [selectedModel, setSelectedModel] = useState(0)
+  const [highlightedModel, setHighlightedModel] = useState(-1)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [promptTyped, setPromptTyped] = useState('')
+  const [responseTyped, setResponseTyped] = useState('')
+  const [sendPulse, setSendPulse] = useState(false)
+  const [showUserMsg, setShowUserMsg] = useState(false)
+  const [showAiMsg, setShowAiMsg] = useState(false)
+  const loopRef = useRef(null)
 
-function Sidebar({ activeScene }) {
-  const activeIdx = SCENE_SIDEBAR_ACTIVE[activeScene] ?? 3
+  useEffect(() => {
+    if (!isActive) {
+      setPhase('idle')
+      setSelectedModel(0)
+      setHighlightedModel(-1)
+      setPickerOpen(false)
+      setPromptTyped('')
+      setResponseTyped('')
+      setSendPulse(false)
+      setShowUserMsg(false)
+      setShowAiMsg(false)
+      if (loopRef.current) loopRef.current.forEach(clearTimeout)
+      return
+    }
+
+    const timers = []
+    const t = (fn, ms) => { const id = setTimeout(fn, ms); timers.push(id); return id }
+
+    const runLoop = () => {
+      setPhase('idle')
+      setPickerOpen(false)
+      setHighlightedModel(-1)
+      setPromptTyped('')
+      setResponseTyped('')
+      setShowUserMsg(false)
+      setShowAiMsg(false)
+      setSendPulse(false)
+      setSelectedModel(0)
+
+      // Phase: picker opens at 600ms
+      t(() => {
+        setPhase('picker')
+        setPickerOpen(true)
+      }, 600)
+
+      // Hover through models
+      const hoverSchedule = [0, 1, 2, 1]
+      hoverSchedule.forEach((idx, i) => {
+        t(() => setHighlightedModel(idx), 1100 + i * 280)
+      })
+
+      // Click on Claude (index 1) at 2400ms
+      t(() => {
+        setSelectedModel(1)
+        setHighlightedModel(-1)
+      }, 2400)
+
+      // Close picker
+      t(() => {
+        setPickerOpen(false)
+      }, 2700)
+
+      // Start typing prompt at 3300ms
+      t(() => setPhase('prompt'), 3300)
+      const promptStart = 3400
+      const promptSpeed = 38
+      PROMPT_TEXT.split('').forEach((_, i) => {
+        t(() => setPromptTyped(PROMPT_TEXT.slice(0, i + 1)), promptStart + i * promptSpeed)
+      })
+      const promptEnd = promptStart + PROMPT_TEXT.length * promptSpeed
+
+      // Send pulse + clear input + show user message
+      t(() => {
+        setSendPulse(true)
+        t(() => setSendPulse(false), 280)
+      }, promptEnd + 250)
+
+      t(() => {
+        setShowUserMsg(true)
+        setPromptTyped('')
+        setPhase('thinking')
+      }, promptEnd + 600)
+
+      // AI thinking, then typing response
+      const responseStart = promptEnd + 1700
+      t(() => {
+        setPhase('responding')
+        setShowAiMsg(true)
+        if (onAction) onAction('model')
+      }, responseStart)
+
+      const responseSpeed = 22
+      RESPONSE_TEXT.split('').forEach((_, i) => {
+        t(() => setResponseTyped(RESPONSE_TEXT.slice(0, i + 1)), responseStart + i * responseSpeed)
+      })
+      const responseEnd = responseStart + RESPONSE_TEXT.length * responseSpeed
+
+      // Hold then loop
+      t(() => {
+        if (onAction) onAction('inbox')
+      }, responseEnd + 200)
+
+      t(runLoop, responseEnd + 2800)
+    }
+
+    runLoop()
+    loopRef.current = timers
+    return () => timers.forEach(clearTimeout)
+  }, [isActive, onAction])
+
+  const model = MODELS[selectedModel]
+
   return (
-    <div className="w-10 bg-white border-r border-gray-100 flex flex-col items-center py-3 gap-3 shrink-0">
-      {SIDEBAR_ICONS.map((Icon, i) => (
-        <div
-          key={i}
-          className="w-7 h-7 rounded-lg flex items-center justify-center transition-colors duration-300"
-          style={{ backgroundColor: i === activeIdx ? 'rgba(56, 89, 168, 0.1)' : 'transparent' }}
-        >
-          <Icon className="w-3.5 h-3.5" strokeWidth={1.5} style={{ color: i === activeIdx ? '#3859a8' : '#a0a0a0' }} />
-        </div>
-      ))}
-    </div>
-  )
-}
+    <div className="w-full h-full flex flex-col bg-white text-[10px] relative overflow-hidden">
+      {/* Top bar with model picker */}
+      <div className="shrink-0 flex items-center justify-between px-3 pt-3 pb-2 border-b border-gray-100 relative">
+        <div className="relative">
+          <button
+            className="flex items-center gap-1.5 px-2 py-1 rounded-lg transition-colors"
+            style={{
+              backgroundColor: pickerOpen ? `${model.color}10` : 'transparent',
+              border: `1px solid ${pickerOpen ? `${model.color}40` : '#e5e7eb'}`,
+            }}
+          >
+            <span className="w-2 h-2 rounded-full" style={{ backgroundColor: model.color }} />
+            <span className="text-[10px] font-semibold text-gray-900">{model.name}</span>
+            <ChevronDown
+              className="w-2.5 h-2.5 text-gray-400 transition-transform duration-300"
+              strokeWidth={2}
+              style={{ transform: pickerOpen ? 'rotate(180deg)' : 'rotate(0deg)' }}
+            />
+          </button>
 
-function ModelSelectionScene({ progress }) {
-  return (
-    <div className="flex-1 flex flex-col p-3 min-w-0">
-      <div className="flex items-center justify-between mb-2.5">
-        <p className="text-[11px] font-semibold text-gray-900">Select a Model</p>
-        <div className="px-2 py-0.5 rounded-full text-[8px] font-medium text-white" style={{ backgroundColor: '#3859a8' }}>
-          Configure
-        </div>
-      </div>
-
-      <div className="grid grid-cols-2 gap-2">
-        {MODELS.map((model, i) => {
-          const isSelected = i === SELECTED_MODEL && progress > 0.4
-          return (
-            <div
-              key={model.name}
-              className="rounded-lg border p-2 relative transition-all duration-300"
-              style={{
-                borderColor: isSelected ? model.color : '#e5e7eb',
-                backgroundColor: isSelected ? `${model.color}08` : '#fff',
-                transform: isSelected ? 'scale(1.02)' : 'scale(1)',
-              }}
-            >
-              {isSelected && (
-                <div
-                  className="absolute top-1.5 right-1.5 w-4 h-4 rounded-full flex items-center justify-center"
-                  style={{ backgroundColor: model.color }}
-                >
-                  <Check className="w-2.5 h-2.5 text-white" strokeWidth={2.5} />
+          <AnimatePresence>
+            {pickerOpen && (
+              <motion.div
+                initial={{ opacity: 0, y: -4, scale: 0.96 }}
+                animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: -4, scale: 0.96 }}
+                transition={{ duration: 0.2 }}
+                className="absolute top-full left-0 mt-1 w-[170px] rounded-xl bg-white z-30 overflow-hidden"
+                style={{
+                  border: '1px solid #e5e7eb',
+                  boxShadow: '0 12px 32px rgba(15,17,41,0.10), 0 2px 8px rgba(15,17,41,0.05)',
+                }}
+              >
+                <div className="px-2 py-1.5 border-b border-gray-100">
+                  <p className="text-[8px] uppercase tracking-wider text-gray-400 font-semibold">Models</p>
                 </div>
-              )}
-              <div className="flex items-center gap-1.5 mb-1">
-                <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: model.color }} />
-                <p className="text-[10px] font-semibold text-gray-900">{model.name}</p>
-              </div>
-              <p className="text-[8px] text-gray-400">{model.tag}</p>
-            </div>
-          )
-        })}
-      </div>
-    </div>
-  )
-}
-
-function ChatScene() {
-  const selectedModel = MODELS[SELECTED_MODEL]
-  return (
-    <div className="flex-1 flex flex-col p-3 min-w-0">
-      <div className="flex items-center justify-between mb-2.5">
-        <div className="flex items-center gap-1.5">
-          <div className="w-2.5 h-2.5 rounded-full" style={{ backgroundColor: selectedModel.color }} />
-          <p className="text-[11px] font-semibold text-gray-900">{selectedModel.name} Chat</p>
+                <div className="py-1">
+                  {MODELS.map((m, i) => {
+                    const isHighlighted = i === highlightedModel
+                    const isSelected = i === selectedModel
+                    return (
+                      <div
+                        key={m.name}
+                        className="flex items-center gap-2 px-2 py-1.5 transition-colors"
+                        style={{
+                          backgroundColor: isHighlighted ? `${m.color}10` : 'transparent',
+                        }}
+                      >
+                        <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: m.color }} />
+                        <div className="flex-1 min-w-0">
+                          <p className="text-[10px] font-semibold text-gray-900">{m.name}</p>
+                          <p className="text-[8px] text-gray-400">{m.provider}</p>
+                        </div>
+                        {isSelected && (
+                          <Check className="w-2.5 h-2.5" style={{ color: m.color }} strokeWidth={2.5} />
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>
         </div>
+
         <div className="flex items-center gap-1">
-          <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
+          <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
           <span className="text-[8px] text-green-600">Online</span>
         </div>
       </div>
 
-      <div className="flex-1 overflow-hidden">
-        {CHAT_MESSAGES.map((msg, i) => (
-          <div
-            key={i}
-            className={`flex mb-1.5 ${msg.role === 'user' ? 'justify-end' : 'items-end gap-1.5'}`}
-          >
-            {msg.role === 'ai' && (
+      {/* Chat area */}
+      <div className="flex-1 px-3 py-3 overflow-hidden flex flex-col">
+        <AnimatePresence mode="wait">
+          {!showUserMsg && !showAiMsg ? (
+            <motion.div
+              key="greeting"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.3 }}
+              className="flex-1 flex flex-col items-center justify-center gap-2"
+            >
               <div
-                className="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
-                style={{ background: `linear-gradient(135deg, ${selectedModel.color}, ${selectedModel.color}cc)` }}
+                className="w-9 h-9 rounded-2xl flex items-center justify-center"
+                style={{
+                  background: `linear-gradient(135deg, ${model.color}, ${model.color}cc)`,
+                  boxShadow: `0 4px 14px ${model.color}33`,
+                }}
               >
-                <Logo size={9} tone="on-dark" animate={false} />
+                <Logo size={16} tone="on-dark" animate={false} />
               </div>
-            )}
-            <div
-              className={`max-w-[80%] px-2 py-1.5 text-[9px] leading-[1.4] ${
-                msg.role === 'user'
-                  ? 'rounded-xl rounded-br-sm text-white'
-                  : 'rounded-xl rounded-bl-sm text-gray-900 bg-[#f1f3f5]'
-              }`}
-              style={msg.role === 'user' ? { backgroundColor: '#3859a8' } : undefined}
+              <div className="text-center">
+                <p className="text-[12px] font-bold text-gray-900">Good afternoon</p>
+                <p className="text-[9px] text-gray-400 mt-0.5">Powered by {model.name}</p>
+              </div>
+            </motion.div>
+          ) : (
+            <motion.div
+              key="conversation"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{ duration: 0.3 }}
+              className="flex-1 flex flex-col gap-2"
             >
-              {msg.text}
-            </div>
-          </div>
-        ))}
+              {showUserMsg && (
+                <motion.div
+                  initial={{ opacity: 0, y: 8, scale: 0.95 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  transition={{ duration: 0.3 }}
+                  className="flex justify-end"
+                >
+                  <div
+                    className="max-w-[80%] px-2.5 py-1.5 text-[10px] leading-[1.4] rounded-xl rounded-br-sm text-gray-900"
+                    style={{ backgroundColor: '#f1f3f5' }}
+                  >
+                    {PROMPT_TEXT}
+                  </div>
+                </motion.div>
+              )}
 
-        <div className="flex flex-col items-center py-2 my-1">
-          <div className="w-7 h-7 rounded-xl flex items-center justify-center" style={{ background: 'rgba(56, 89, 168, 0.08)' }}>
-            <Calendar size={12} strokeWidth={1.5} style={{ color: '#3859a8' }} />
-          </div>
-          <div className="flex items-center gap-1 mt-1">
-            <div className="w-1.5 h-1.5 rounded-full bg-green-500" />
-            <span className="text-[8px] font-semibold" style={{ color: '#3859a8' }}>Callback scheduled</span>
-            <span className="text-[7px] text-gray-400">2:00 PM</span>
-          </div>
-        </div>
-      </div>
+              {(phase === 'thinking' || phase === 'responding') && (
+                <div className="flex items-end gap-1.5">
+                  <div className="relative shrink-0" style={{ width: 22, height: 22 }}>
+                    {phase === 'thinking' && [0, 1, 2].map((i) => (
+                      <span
+                        key={i}
+                        className="absolute rounded-full"
+                        style={{
+                          width: 22, height: 22,
+                          top: 0, left: 0,
+                          border: `1.5px solid ${model.color}`,
+                          opacity: 0.35 - i * 0.08,
+                          animation: `ring-expand 1.4s ease-out ${i * 0.35}s infinite`,
+                        }}
+                      />
+                    ))}
+                    <div
+                      className="w-[22px] h-[22px] rounded-full flex items-center justify-center relative"
+                      style={{
+                        background: `linear-gradient(135deg, ${model.color}, ${model.color}cc)`,
+                        animation: phase === 'thinking' ? 'orb-pulse 1.2s ease-in-out infinite' : 'none',
+                      }}
+                    >
+                      <Logo size={10} tone="on-dark" animate={false} />
+                    </div>
+                  </div>
 
-      <div className="shrink-0 pt-1.5 border-t border-gray-100 flex items-center gap-2">
-        <div className="flex-1 bg-gray-50 rounded-full px-2.5 py-1 text-[8px] text-gray-400">
-          Type a message...
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function AgentCreationScene({ progress }) {
-  const subProgress = (progress - 0.66) / 0.34
-  const phase = subProgress < 0.33 ? 'form' : subProgress < 0.66 ? 'creating' : 'success'
-
-  return (
-    <div className="flex-1 flex flex-col p-3 min-w-0">
-      <div className="flex items-center justify-between mb-2.5">
-        <p className="text-[11px] font-semibold text-gray-900">Create New Agent</p>
-      </div>
-
-      <div className="flex-1 flex items-start justify-center pt-2">
-        <div className="w-full rounded-lg border border-gray-200 bg-white p-3">
-          <div className="space-y-2 mb-3">
-            <div>
-              <p className="text-[8px] text-gray-400 mb-0.5">Name</p>
-              <p className="text-[10px] text-gray-900 font-medium">Sales Assistant</p>
-            </div>
-            <div>
-              <p className="text-[8px] text-gray-400 mb-0.5">Model</p>
-              <div className="flex items-center gap-1">
-                <div className="w-2 h-2 rounded-full" style={{ backgroundColor: MODELS[SELECTED_MODEL].color }} />
-                <p className="text-[10px] text-gray-900 font-medium">{MODELS[SELECTED_MODEL].name}</p>
-              </div>
-            </div>
-            <div>
-              <p className="text-[8px] text-gray-400 mb-0.5">Purpose</p>
-              <p className="text-[10px] text-gray-900 font-medium">Follow-up & scheduling</p>
-            </div>
-          </div>
-
-          {phase === 'form' && (
-            <button
-              className="w-full py-1.5 rounded-lg text-[10px] font-semibold text-white"
-              style={{ backgroundColor: '#3859a8' }}
-            >
-              Create Agent
-            </button>
+                  {phase === 'thinking' ? (
+                    <div
+                      className="flex items-center gap-1 px-2.5 py-2 rounded-xl rounded-bl-sm"
+                      style={{ backgroundColor: model.color }}
+                    >
+                      {[0, 1, 2].map((d) => (
+                        <span
+                          key={d}
+                          className="w-1 h-1 rounded-full"
+                          style={{
+                            backgroundColor: '#ffffff',
+                            opacity: 0.7,
+                            animation: `typing-dot 1.4s ease-in-out ${d * 0.2}s infinite`,
+                          }}
+                        />
+                      ))}
+                    </div>
+                  ) : (
+                    <div
+                      className="max-w-[82%] px-2.5 py-1.5 text-[10px] leading-[1.4] rounded-xl rounded-bl-sm text-white"
+                      style={{ backgroundColor: model.color }}
+                    >
+                      {responseTyped}
+                      {phase === 'responding' && responseTyped.length < RESPONSE_TEXT.length && (
+                        <span
+                          className="inline-block w-px ml-px align-middle"
+                          style={{
+                            height: 9,
+                            backgroundColor: 'rgba(255,255,255,0.8)',
+                            animation: 'caret-blink 0.8s step-end infinite',
+                          }}
+                        />
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </motion.div>
           )}
-
-          {phase === 'creating' && (
-            <div className="w-full py-1.5 rounded-lg text-[10px] font-semibold text-white flex items-center justify-center gap-1.5" style={{ backgroundColor: '#3859a8' }}>
-              <Loader2 className="w-3 h-3 animate-spin" />
-              Creating...
-            </div>
-          )}
-
-          {phase === 'success' && (
-            <div className="w-full py-2 rounded-lg border border-green-200 bg-green-50 flex flex-col items-center gap-1">
-              <div className="w-5 h-5 rounded-full bg-green-500 flex items-center justify-center">
-                <Check className="w-3 h-3 text-white" strokeWidth={2.5} />
-              </div>
-              <p className="text-[10px] font-semibold text-green-700">Agent Created</p>
-              <div className="flex items-center gap-1">
-                <p className="text-[9px] text-gray-600">Sales Assistant</p>
-                <span className="px-1.5 py-0.5 rounded-full text-[7px] font-medium bg-green-100 text-green-700">Active</span>
-              </div>
-            </div>
-          )}
-        </div>
+        </AnimatePresence>
       </div>
-    </div>
-  )
-}
 
-export function SpaceScreen({ isActive, onAction, progressRef }) {
-  const sceneRefs = useRef([])
-  const tickerRef = useRef(null)
-  const sceneIndexRef = useRef(0)
-
-  useEffect(() => {
-    if (!isActive) {
-      sceneRefs.current.forEach((el) => {
-        if (el) gsap.set(el, { clearProps: 'all' })
-      })
-      return
-    }
-
-    const updateScenes = () => {
-      const progress = progressRef?.current ?? 0
-      const sceneFloat = progress * 3
-      const activeScene = Math.min(Math.floor(sceneFloat), 2)
-      sceneIndexRef.current = activeScene
-
-      sceneRefs.current.forEach((el, i) => {
-        if (!el) return
-
-        if (i === activeScene) {
-          gsap.set(el, { opacity: 1, visibility: 'visible', zIndex: 2 })
-        } else {
-          const dist = Math.abs(i - sceneFloat)
-          const fade = Math.max(0, 1 - dist * 4)
-          if (fade > 0.01) {
-            gsap.set(el, { opacity: fade, visibility: 'visible', zIndex: 1 })
-          } else {
-            gsap.set(el, { opacity: 0, visibility: 'hidden', zIndex: 0 })
-          }
-        }
-      })
-    }
-
-    gsap.ticker.add(updateScenes)
-    tickerRef.current = updateScenes
-
-    return () => {
-      gsap.ticker.remove(updateScenes)
-    }
-  }, [isActive, progressRef])
-
-  const progress = progressRef?.current ?? 0
-  const activeScene = Math.min(Math.floor(progress * 3), 2)
-
-  return (
-    <div className="w-full h-full flex bg-[#fafbfd] text-[10px] overflow-hidden">
-      <Sidebar activeScene={activeScene} />
-
-      <div className="flex-1 relative min-w-0">
-        <div
-          ref={(el) => { sceneRefs.current[0] = el }}
-          className="absolute inset-0 flex"
-        >
-          <ModelSelectionScene progress={progress} />
+      {/* Input bar */}
+      <div className="shrink-0 px-3 py-2 border-t border-gray-100 flex items-center gap-2">
+        <Paperclip className="w-3 h-3 text-gray-400 shrink-0" strokeWidth={1.6} />
+        <div className="flex-1 bg-gray-50 rounded-full px-3 py-1 text-[9px] flex items-center min-h-5">
+          {phase === 'prompt' && promptTyped ? (
+            <span className="text-gray-800">
+              {promptTyped}
+              <span
+                className="inline-block w-px ml-px align-middle"
+                style={{
+                  height: 9,
+                  backgroundColor: model.color,
+                  animation: 'caret-blink 0.8s step-end infinite',
+                }}
+              />
+            </span>
+          ) : (
+            <span className="text-gray-400">Ask anything...</span>
+          )}
         </div>
-
+        <Mic className="w-3 h-3 text-gray-400 shrink-0" strokeWidth={1.6} />
         <div
-          ref={(el) => { sceneRefs.current[1] = el }}
-          className="absolute inset-0 flex"
+          className="w-6 h-6 rounded-full flex items-center justify-center shrink-0"
+          style={{
+            backgroundColor: model.color,
+            transform: sendPulse ? 'scale(1.18)' : 'scale(1)',
+            boxShadow: sendPulse ? `0 0 0 4px ${model.color}33` : 'none',
+            transition: 'transform 0.2s ease-out, box-shadow 0.2s ease-out',
+          }}
         >
-          <ChatScene />
-        </div>
-
-        <div
-          ref={(el) => { sceneRefs.current[2] = el }}
-          className="absolute inset-0 flex"
-        >
-          <AgentCreationScene progress={progress} />
+          <Send className="w-2.5 h-2.5 text-white" strokeWidth={1.8} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- **Receptionist & Messenger**: reversed bubble colors (AI = brand blue/white, user = grey/dark) and bumped chat-row spacing from `mb-1.5` → `mb-3`.
- **Messenger**: replaced static typing-dots bubble with a continuous **type → send → land** cycle in the input field (per-channel color, expanding-ring waves on the avatar, blinking caret, send-button pulse). Added a 3rd message to the Teams conversation so it matches the other channels.
- **Outreach**: rewrote the screen as a phased loop — Excel file upload (with progress bar) → "247 contacts imported" success state → sequential Call → SMS → Email channel rows with per-channel progress + green checkmarks → final-stats summary (Contacted / Reached / Booked).
- **Space**: rewrote as a single self-contained animation — model-picker dropdown opens, hovers through providers, selects Claude 4.7 → user types prompt → AI thinking (ring-wave avatar + typing dots) → AI types response in model color. Reduced `SPACE_SCENES` from 3 → 1 in `ScrollProductShowcase` since the scroll-driven 3-scene design is gone.
- **Stats section**: switched from `surface-navy` (dark bg) to a light bg consistent with the rest of the page; cards use a soft white-glass treatment with subtle blue border.
- **Floating cards**: removed entirely from `SlideDevice` (per design ask) — devices now render clean.
- **Homepage**: commented out `LogoCloud` ("Trusted by forward-thinking businesses").
- **globals.css**: added `caret-blink` and `sent-bubble-in` keyframes used by the new input/typing animations.

## Test plan
- [ ] `npm run lint` passes
- [ ] `npm run build` passes
- [ ] Scroll through the product showcase on desktop:
  - [ ] Receptionist call replays cleanly with reversed bubble colors
  - [ ] Each Messenger channel (SMS / Web / WhatsApp / Teams) shows the typing→send→bubble cycle in the input field with no "Type a message..." dead time
  - [ ] Outreach: Excel upload → parsed checkmark → 3 channel rows fill sequentially → summary stats animate up
  - [ ] Space: dropdown opens, model selection happens, prompt types, AI responds — model color updates the orb / send button / response bubble
  - [ ] Avatar slide cards aren't clipped at the viewport edge
- [ ] No console errors during the full scroll
- [ ] Stats section reads cleanly on light bg
