### PR TITLE
Browser mockup + device glow + hero polish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,19 @@ dist-ssr
 test-results
 playwright-report
 .playwright-mcp
+# Ad-hoc Playwright screenshots dropped at repo root during dev/audits
+/d-*.png
+/d-*.jpg
+/d-*.jpeg
+/m-*.png
+/m-*.jpg
+/m-*.jpeg
+/t-*.png
+/t-*.jpg
+/t-*.jpeg
+/mobile-*.png
+/mobile-*.jpg
+/mobile-*.jpeg
 
 # Editor directories and files
 .vscode/*

--- a/app/globals.css
+++ b/app/globals.css
@@ -756,6 +756,42 @@ textarea:focus-visible {
   animation: phone-vibrate 0.6s ease-in-out 3;
 }
 
+/* ── Showcase device glow halo ──
+   Multi-color cyan→blue→purple→pink wash that pulses behind each device.
+   Inspired by the CogniDrift mockup: subtle outer bloom + tighter inner halo. */
+@keyframes device-glow-pulse-outer {
+  0%, 100% {
+    opacity: 0.45;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.75;
+    transform: scale(1.04);
+  }
+}
+
+@keyframes device-glow-pulse-inner {
+  0%, 100% {
+    opacity: 0.25;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(1.03);
+  }
+}
+
+.device-glow-outer {
+  animation: device-glow-pulse-outer 4.8s ease-in-out infinite;
+  will-change: transform, opacity;
+}
+
+.device-glow-inner {
+  animation: device-glow-pulse-inner 3.6s ease-in-out infinite;
+  animation-delay: -1.2s;
+  will-change: transform, opacity;
+}
+
 /* ── Showcase device responsive scaling ──
    Each device renders at its natural pixel dimensions, then is scaled
    visually AND its layout box is reduced to the scaled size, so the page
@@ -782,23 +818,27 @@ textarea:focus-visible {
 [data-device-frame][data-device-type="phone"]   { --w: 320px; --h: 660px; --s: 0.82; }
 [data-device-frame][data-device-type="laptop"]  { --w: 720px; --h: 460px; --s: 0.42; }
 [data-device-frame][data-device-type="monitor"] { --w: 460px; --h: 330px; --s: 0.65; }
+[data-device-frame][data-device-type="browser"] { --w: 820px; --h: 560px; --s: 0.38; }
 
 @media (min-width: 480px) {
   [data-device-frame][data-device-type="phone"]   { --s: 0.95; }
   [data-device-frame][data-device-type="laptop"]  { --s: 0.55; }
   [data-device-frame][data-device-type="monitor"] { --s: 0.85; }
+  [data-device-frame][data-device-type="browser"] { --s: 0.5; }
 }
 
 @media (min-width: 640px) {
   [data-device-frame][data-device-type="phone"]   { --s: 1; }
   [data-device-frame][data-device-type="laptop"]  { --s: 0.78; }
   [data-device-frame][data-device-type="monitor"] { --s: 1; }
+  [data-device-frame][data-device-type="browser"] { --s: 0.7; }
 }
 
 @media (min-width: 768px) {
   [data-device-frame][data-device-type="phone"]   { --s: 1; }
   [data-device-frame][data-device-type="laptop"]  { --s: 0.92; }
   [data-device-frame][data-device-type="monitor"] { --s: 1; }
+  [data-device-frame][data-device-type="browser"] { --s: 0.78; }
 }
 
 @media (min-width: 1024px) {
@@ -806,10 +846,12 @@ textarea:focus-visible {
   [data-device-frame][data-device-type="phone"]   { --s: 1; }
   [data-device-frame][data-device-type="laptop"]  { --s: 0.55; }
   [data-device-frame][data-device-type="monitor"] { --s: 0.85; }
+  [data-device-frame][data-device-type="browser"] { --s: 0.5; }
 }
 
 @media (min-width: 1280px) {
   [data-device-frame][data-device-type="phone"]   { --s: 1; }
   [data-device-frame][data-device-type="laptop"]  { --s: 0.72; }
   [data-device-frame][data-device-type="monitor"] { --s: 1; }
+  [data-device-frame][data-device-type="browser"] { --s: 0.68; }
 }

--- a/components/sections/Hero.jsx
+++ b/components/sections/Hero.jsx
@@ -91,8 +91,8 @@ export function Hero() {
   useEffect(() => setMounted(true), [])
 
   return (
-    <section className="relative min-h-screen flex items-center overflow-hidden pt-20">
-      {/* Background handled by BrandBackground */}
+    <section className="relative min-h-screen flex items-center overflow-hidden pt-20 bg-white">
+      {/* Clean white base — atmospheric BrandBackground sits behind via fixed positioning */}
 
       <div className="relative z-10 max-w-7xl mx-auto px-6 w-full">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-8 items-center min-h-[calc(100vh-80px)] py-16">

--- a/components/sections/HowItWorks.jsx
+++ b/components/sections/HowItWorks.jsx
@@ -122,10 +122,10 @@ function StepCard({ step, index }) {
     >
       {/* Step number */}
       <span
-        className="text-[3.5rem] font-extrabold leading-none select-none"
+        className="block text-[3.5rem] font-extrabold leading-[1.25] select-none pt-1"
         style={{
           fontFamily: 'var(--font-jetbrains), JetBrains Mono, monospace',
-          background: `linear-gradient(135deg, ${color}, ${color}55)`,
+          background: `linear-gradient(135deg, ${color}, ${color}aa)`,
           WebkitBackgroundClip: 'text',
           WebkitTextFillColor: 'transparent',
           backgroundClip: 'text',

--- a/components/sections/showcase/SlideDevice.jsx
+++ b/components/sections/showcase/SlideDevice.jsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useRef } from 'react'
 import { PhoneMockup } from './devices/PhoneMockup'
 import { LaptopMockup } from './devices/LaptopMockup'
 import { MonitorMockup } from './devices/MonitorMockup'
+import { BrowserMockup } from './devices/BrowserMockup'
 import { ReceptionistScreen } from './screens/ReceptionistScreen'
 import { MessengerScreen } from './screens/MessengerScreen'
 import { OutreachScreen } from './screens/OutreachScreen'
@@ -22,12 +23,19 @@ const DEVICES = {
   phone: PhoneMockup,
   laptop: LaptopMockup,
   monitor: MonitorMockup,
+  browser: BrowserMockup,
 }
 
 const TILT = {
   phone: 'none',
   laptop: 'none',
   monitor: 'none',
+  browser: 'none',
+}
+
+const BROWSER_URL = {
+  space: 'app.jotillabs.com',
+  avatar: 'app.jotillabs.com/avatar',
 }
 
 export function SlideDevice({ slug, deviceType, isActive, messengerProgressRef, spaceProgressRef }) {
@@ -90,7 +98,13 @@ export function SlideDevice({ slug, deviceType, isActive, messengerProgressRef, 
                 </div>
               </div>
             ) : (
-              <Device vibrate={vibrate && isActive} glass>
+              <Device
+                vibrate={vibrate && isActive}
+                glass
+                {...(deviceType === 'browser' && BROWSER_URL[slug]
+                  ? { url: BROWSER_URL[slug] }
+                  : {})}
+              >
                 <Screen
                   isActive={isActive}
                   onAction={onAction}

--- a/components/sections/showcase/data.js
+++ b/components/sections/showcase/data.js
@@ -51,7 +51,7 @@ export const PRODUCT_SLIDES = [
       'Real-time conversation analytics',
       'Unified inbox across all channels',
     ],
-    deviceType: 'laptop',
+    deviceType: 'browser',
   },
   {
     slug: 'avatar',
@@ -64,6 +64,6 @@ export const PRODUCT_SLIDES = [
       'Natural conversation with real expressions',
       'Guided selling and onboarding',
     ],
-    deviceType: 'monitor',
+    deviceType: 'browser',
   },
 ]

--- a/components/sections/showcase/devices/BrowserMockup.jsx
+++ b/components/sections/showcase/devices/BrowserMockup.jsx
@@ -1,0 +1,78 @@
+import { DeviceGlow } from './DeviceGlow'
+
+export function BrowserMockup({ children, glass = false, url = 'app.jotillabs.com' }) {
+  return (
+    <div className="flex flex-col items-center relative">
+      <DeviceGlow radius={20} inset={-30} intensity={0.9} />
+      <div
+        className="w-[820px] rounded-2xl overflow-hidden relative"
+        style={{
+          border: glass
+            ? '1px solid rgba(255,255,255,0.55)'
+            : '1px solid rgba(0,0,0,0.06)',
+          background: glass
+            ? 'linear-gradient(160deg, rgba(255,255,255,0.88) 0%, rgba(240,240,245,0.7) 50%, rgba(255,255,255,0.82) 100%)'
+            : '#ffffff',
+          backdropFilter: glass ? 'blur(20px) saturate(1.2)' : undefined,
+          WebkitBackdropFilter: glass ? 'blur(20px) saturate(1.2)' : undefined,
+          boxShadow: glass
+            ? [
+                'inset 0 1px 0 rgba(255,255,255,0.85)',
+                '0 4px 16px rgba(0,0,0,0.05)',
+                '0 12px 40px rgba(0,0,0,0.06)',
+                '0 32px 80px rgba(0,0,0,0.05)',
+              ].join(', ')
+            : [
+                '0 1px 0 rgba(255,255,255,0.5) inset',
+                '0 4px 12px rgba(15,17,41,0.10)',
+                '0 14px 36px rgba(15,17,41,0.14)',
+                '0 36px 72px rgba(15,17,41,0.12)',
+              ].join(', '),
+        }}
+      >
+        {/* Browser chrome */}
+        <div
+          className="flex items-center gap-3 px-5 py-3 border-b border-black/5"
+          style={{
+            background: glass
+              ? 'rgba(250, 250, 252, 0.75)'
+              : 'linear-gradient(180deg, #f8f8fa, #eeeef2)',
+            backdropFilter: glass ? 'blur(12px)' : undefined,
+            WebkitBackdropFilter: glass ? 'blur(12px)' : undefined,
+          }}
+        >
+          {/* Traffic-light dots */}
+          <div className="flex gap-2 shrink-0">
+            <span className="w-3 h-3 rounded-full bg-[#ff5f57]" />
+            <span className="w-3 h-3 rounded-full bg-[#febc2e]" />
+            <span className="w-3 h-3 rounded-full bg-[#28c840]" />
+          </div>
+          {/* URL bar */}
+          <div className="flex-1 mx-8">
+            <div
+              className="bg-white/90 rounded-md px-4 py-1.5 text-[12px] text-gray-500 text-center border border-black/5"
+              style={{ fontFamily: 'var(--font-inter), Inter, sans-serif' }}
+            >
+              {url}
+            </div>
+          </div>
+          {/* Right-side spacer to balance the dots */}
+          <div className="w-[60px] shrink-0" />
+        </div>
+        {/* Screen content */}
+        <div className="bg-white aspect-[16/10] overflow-hidden relative">
+          {children}
+          {glass && (
+            <div
+              className="absolute inset-0 pointer-events-none z-10"
+              style={{
+                background:
+                  'linear-gradient(135deg, rgba(255,255,255,0.18) 0%, transparent 30%, transparent 70%, rgba(255,255,255,0.10) 100%)',
+              }}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/sections/showcase/devices/DeviceGlow.jsx
+++ b/components/sections/showcase/devices/DeviceGlow.jsx
@@ -1,0 +1,34 @@
+export function DeviceGlow({ radius = 60, inset = -18, intensity = 1 }) {
+  return (
+    <>
+      {/* Outer wash — soft, large blur */}
+      <div
+        aria-hidden="true"
+        className="device-glow-outer pointer-events-none"
+        style={{
+          position: 'absolute',
+          inset,
+          borderRadius: radius,
+          background:
+            'linear-gradient(135deg, rgba(6,182,212,0.55), rgba(59,130,246,0.55), rgba(139,92,246,0.6), rgba(217,70,239,0.55))',
+          filter: 'blur(36px)',
+          opacity: 0.55 * intensity,
+        }}
+      />
+      {/* Inner halo — tighter, sharper colour */}
+      <div
+        aria-hidden="true"
+        className="device-glow-inner pointer-events-none"
+        style={{
+          position: 'absolute',
+          inset: typeof inset === 'number' ? inset + 8 : inset,
+          borderRadius: radius,
+          background:
+            'linear-gradient(135deg, rgba(6,182,212,0.7), rgba(139,92,246,0.7), rgba(217,70,239,0.6))',
+          filter: 'blur(14px)',
+          opacity: 0.35 * intensity,
+        }}
+      />
+    </>
+  )
+}

--- a/components/sections/showcase/devices/LaptopMockup.jsx
+++ b/components/sections/showcase/devices/LaptopMockup.jsx
@@ -1,3 +1,5 @@
+import { DeviceGlow } from './DeviceGlow'
+
 export function LaptopMockup({ children, glass = false }) {
   const borderStyle = glass
     ? '2px solid rgba(255, 255, 255, 0.5)'
@@ -8,7 +10,8 @@ export function LaptopMockup({ children, glass = false }) {
     : undefined
 
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center relative">
+      <DeviceGlow radius={32} inset={-32} intensity={0.9} />
       {/* Screen */}
       <div
         className="w-160 rounded-t-xl overflow-hidden relative"

--- a/components/sections/showcase/devices/MonitorMockup.jsx
+++ b/components/sections/showcase/devices/MonitorMockup.jsx
@@ -1,6 +1,9 @@
+import { DeviceGlow } from './DeviceGlow'
+
 export function MonitorMockup({ children, glass = false }) {
   return (
-    <div className="flex flex-col items-center">
+    <div className="flex flex-col items-center relative">
+      <DeviceGlow radius={26} inset={-30} intensity={0.9} />
       {/* Screen */}
       <div
         className="w-[460px] rounded-xl overflow-hidden relative"

--- a/components/sections/showcase/devices/PhoneMockup.jsx
+++ b/components/sections/showcase/devices/PhoneMockup.jsx
@@ -1,7 +1,10 @@
+import { DeviceGlow } from './DeviceGlow'
+
 export function PhoneMockup({ children, vibrate = false, glass = false }) {
   if (!glass) {
     return (
       <div className="relative" style={{ perspective: 1200 }}>
+        <DeviceGlow radius={62} inset={-22} />
         <div className="absolute left-[-2.5px] top-[90px] w-[3px] h-[20px] rounded-l-sm" style={{ background: 'linear-gradient(180deg, #3a3a40, #2a2a30)' }} />
         <div className="absolute left-[-2.5px] top-[124px] w-[3px] h-[32px] rounded-l-sm" style={{ background: 'linear-gradient(180deg, #3a3a40, #2a2a30)' }} />
         <div className="absolute left-[-2.5px] top-[164px] w-[3px] h-[32px] rounded-l-sm" style={{ background: 'linear-gradient(180deg, #3a3a40, #2a2a30)' }} />
@@ -32,6 +35,7 @@ export function PhoneMockup({ children, vibrate = false, glass = false }) {
 
   return (
     <div className="relative" style={{ perspective: 1200 }}>
+      <DeviceGlow radius={62} inset={-22} intensity={0.85} />
       {/* Side buttons -- light silver for glass variant */}
       <div className="absolute left-[-2px] top-[90px] w-[2.5px] h-[20px] rounded-l-sm" style={{ background: 'linear-gradient(180deg, #d8d8dc, #c0c0c4)' }} />
       <div className="absolute left-[-2px] top-[124px] w-[2.5px] h-[32px] rounded-l-sm" style={{ background: 'linear-gradient(180deg, #d8d8dc, #c0c0c4)' }} />

--- a/components/sections/showcase/screens/AvatarScreen.jsx
+++ b/components/sections/showcase/screens/AvatarScreen.jsx
@@ -283,32 +283,6 @@ export function AvatarScreen({ isActive, onAction }) {
 
   return (
     <div className="w-full h-full flex flex-col bg-white relative overflow-hidden">
-      {/* Browser tab chrome */}
-      <div className="shrink-0 flex items-center gap-2 px-3 py-2 bg-gray-50 border-b border-gray-200">
-        <div className="flex items-center gap-1">
-          <span className="w-2.5 h-2.5 rounded-full bg-[#ff5f57]" />
-          <span className="w-2.5 h-2.5 rounded-full bg-[#ffbd2e]" />
-          <span className="w-2.5 h-2.5 rounded-full bg-[#28c840]" />
-        </div>
-        <div className="flex items-center gap-1.5 ml-2">
-          <div className="px-2.5 py-1 bg-white rounded-t-md border-t border-l border-r border-gray-200 flex items-center gap-1.5">
-            <Logo size={9} animate={false} />
-            <span className="text-[9px] font-semibold text-gray-700">JotilAvatar</span>
-            <span className="w-3 h-3 rounded-full hover:bg-gray-200 flex items-center justify-center text-gray-400 text-[8px]">×</span>
-          </div>
-        </div>
-        <div className="flex-1 flex items-center justify-center">
-          <div className="bg-white rounded-md px-3 py-0.5 text-[8px] text-gray-500 font-mono border border-gray-200 max-w-45 w-full text-center">
-            app.jotillabs.com/avatar
-          </div>
-        </div>
-        <div className="flex items-center gap-1">
-          <span className="w-1 h-1 rounded-full bg-gray-300" />
-          <span className="w-1 h-1 rounded-full bg-gray-300" />
-          <span className="w-1 h-1 rounded-full bg-gray-300" />
-        </div>
-      </div>
-
       {/* Content: avatar left, chat right */}
       <div className="flex-1 flex min-h-0">
         {/* Left: Avatar */}
@@ -319,14 +293,14 @@ export function AvatarScreen({ isActive, onAction }) {
               {aiSpeaking && (
                 <div className="absolute top-2 left-2 flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-white/90 backdrop-blur" style={{ boxShadow: '0 2px 6px rgba(0,0,0,0.1)' }}>
                   <span className="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse" />
-                  <span className="text-[7px] font-semibold text-gray-700">LIVE</span>
+                  <span className="text-[11px] font-semibold text-gray-700">LIVE</span>
                 </div>
               )}
             </div>
           </div>
           <div className="shrink-0 px-3 pb-2 pt-1 flex flex-col items-center gap-1">
-            <p className="text-[10px] font-bold text-gray-900">Sarah</p>
-            <p className="text-[8px] text-gray-500">AI Brand Ambassador</p>
+            <p className="text-[14px] font-bold text-gray-900">Sarah</p>
+            <p className="text-[12px] text-gray-500">AI Brand Ambassador</p>
             <div className="flex items-center gap-2 mt-1">
               <div
                 className="w-6 h-6 rounded-full flex items-center justify-center"
@@ -347,11 +321,11 @@ export function AvatarScreen({ isActive, onAction }) {
               <div className="w-5 h-5 rounded-md flex items-center justify-center" style={{ backgroundColor: `${BRAND_BLUE}15` }}>
                 <Logo size={10} animate={false} />
               </div>
-              <p className="text-[10px] font-bold text-gray-900">Live Conversation</p>
+              <p className="text-[14px] font-bold text-gray-900">Live Conversation</p>
             </div>
             <div className="flex items-center gap-1">
               <span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" />
-              <span className="text-[8px] text-green-600">Active</span>
+              <span className="text-[12px] text-green-600">Active</span>
             </div>
           </div>
 
@@ -368,7 +342,7 @@ export function AvatarScreen({ isActive, onAction }) {
                     className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}
                   >
                     <div
-                      className={`max-w-[88%] px-2 py-1.5 text-[9.5px] leading-snug ${
+                      className={`max-w-[88%] px-2 py-1.5 text-[13px] leading-snug ${
                         isUser
                           ? 'rounded-xl rounded-br-sm text-gray-900'
                           : 'rounded-xl rounded-bl-sm text-white'
@@ -401,7 +375,7 @@ export function AvatarScreen({ isActive, onAction }) {
           </div>
 
           <div className="shrink-0 px-3 py-1.5 border-t border-gray-100 flex items-center gap-2">
-            <div className="flex-1 bg-gray-50 rounded-full px-2.5 py-1 text-[8.5px] text-gray-400">
+            <div className="flex-1 bg-gray-50 rounded-full px-2.5 py-1 text-[12px] text-gray-400">
               Type or speak...
             </div>
             <div

--- a/components/sections/showcase/screens/SpaceScreen.jsx
+++ b/components/sections/showcase/screens/SpaceScreen.jsx
@@ -104,8 +104,8 @@ function BarChartCard({ bars, animate }) {
       style={{ boxShadow: `0 4px 12px ${BRAND_BLUE}10` }}
     >
       <div className="flex items-center justify-between mb-2">
-        <p className="text-[9px] font-bold text-gray-700 uppercase tracking-wider">Q4 by channel</p>
-        <p className="text-[8.5px] text-gray-400 font-mono">total $847K</p>
+        <p className="text-[13px] font-bold text-gray-700 uppercase tracking-wider">Q4 by channel</p>
+        <p className="text-[16px] text-gray-400 font-mono">total $847K</p>
       </div>
       <div className="flex items-end justify-around gap-2 h-20">
         {bars.map((bar, i) => {
@@ -116,7 +116,7 @@ function BarChartCard({ bars, animate }) {
                 initial={{ opacity: 0 }}
                 animate={{ opacity: animate ? 1 : 0 }}
                 transition={{ duration: 0.3, delay: 0.4 + i * 0.1 }}
-                className="text-[8px] font-bold text-gray-700 font-mono tabular-nums"
+                className="text-[16px] font-bold text-gray-700 font-mono tabular-nums"
               >
                 ${bar.value}K
               </motion.div>
@@ -140,7 +140,7 @@ function BarChartCard({ bars, animate }) {
       <div className="flex items-center justify-around gap-2 mt-1">
         {bars.map((bar) => (
           <div key={bar.label} className="flex-1 text-center">
-            <p className="text-[8px] text-gray-500">{bar.label}</p>
+            <p className="text-[16px] text-gray-500">{bar.label}</p>
           </div>
         ))}
       </div>
@@ -166,7 +166,7 @@ function SalespersonCard({ data }) {
           className="w-9 h-9 rounded-full flex items-center justify-center"
           style={{ background: `linear-gradient(135deg, ${BRAND_BLUE}, ${BRAND_BLUE}cc)` }}
         >
-          <span className="text-white font-bold text-[11px]">{initials}</span>
+          <span className="text-white font-bold text-[15px]">{initials}</span>
         </div>
         <div
           className="absolute -top-0.5 -right-0.5 w-4 h-4 rounded-full flex items-center justify-center border-2 border-white"
@@ -176,19 +176,19 @@ function SalespersonCard({ data }) {
         </div>
       </div>
       <div className="flex-1 min-w-0">
-        <p className="text-[11px] font-bold text-gray-900 truncate">{data.name}</p>
-        <p className="text-[8.5px] text-gray-500 truncate">{data.role}</p>
+        <p className="text-[15px] font-bold text-gray-900 truncate">{data.name}</p>
+        <p className="text-[16px] text-gray-500 truncate">{data.role}</p>
       </div>
       <div className="flex gap-2.5 shrink-0">
         {data.stats.map((s) => (
           <div key={s.label} className="text-center">
             <p
-              className="text-[11px] font-bold tabular-nums leading-none"
+              className="text-[15px] font-bold tabular-nums leading-none"
               style={{ color: BRAND_BLUE }}
             >
               {s.value}
             </p>
-            <p className="text-[7.5px] text-gray-400 uppercase tracking-wider mt-0.5">{s.label}</p>
+            <p className="text-[15px] text-gray-400 uppercase tracking-wider mt-0.5">{s.label}</p>
           </div>
         ))}
       </div>
@@ -208,7 +208,7 @@ function ChatTopBar({ model, pickerOpen, highlightedModel, selectedModel }) {
           }}
         >
           <span className="w-2 h-2 rounded-full" style={{ backgroundColor: model.color }} />
-          <span className="text-[10px] font-semibold text-gray-900">{model.name}</span>
+          <span className="text-[14px] font-semibold text-gray-900">{model.name}</span>
           <ChevronDown
             className="w-2.5 h-2.5 text-gray-400 transition-transform duration-300"
             strokeWidth={2}
@@ -230,7 +230,7 @@ function ChatTopBar({ model, pickerOpen, highlightedModel, selectedModel }) {
               }}
             >
               <div className="px-2 py-1.5 border-b border-gray-100">
-                <p className="text-[8px] uppercase tracking-wider text-gray-400 font-semibold">Models</p>
+                <p className="text-[16px] uppercase tracking-wider text-gray-400 font-semibold">Models</p>
               </div>
               <div className="py-1">
                 {MODELS.map((m, i) => {
@@ -244,8 +244,8 @@ function ChatTopBar({ model, pickerOpen, highlightedModel, selectedModel }) {
                     >
                       <span className="w-2 h-2 rounded-full shrink-0" style={{ backgroundColor: m.color }} />
                       <div className="flex-1 min-w-0">
-                        <p className="text-[10px] font-semibold text-gray-900">{m.name}</p>
-                        <p className="text-[8px] text-gray-400">{m.provider}</p>
+                        <p className="text-[14px] font-semibold text-gray-900">{m.name}</p>
+                        <p className="text-[16px] text-gray-400">{m.provider}</p>
                       </div>
                       {isSelected && (
                         <Check className="w-2.5 h-2.5" style={{ color: m.color }} strokeWidth={2.5} />
@@ -261,7 +261,7 @@ function ChatTopBar({ model, pickerOpen, highlightedModel, selectedModel }) {
 
       <div className="flex items-center gap-1">
         <span className="w-1.5 h-1.5 rounded-full bg-green-500" />
-        <span className="text-[8px] text-green-600">Online</span>
+        <span className="text-[16px] text-green-600">Online</span>
       </div>
     </div>
   )
@@ -301,8 +301,8 @@ function ChatView({
               <Logo size={18} tone="on-dark" animate={false} />
             </div>
             <div className="text-center">
-              <p className="text-[12px] font-bold text-gray-900">Good afternoon</p>
-              <p className="text-[9px] text-gray-400 mt-0.5">Powered by {model.name}</p>
+              <p className="text-[16px] font-bold text-gray-900">Good afternoon</p>
+              <p className="text-[13px] text-gray-400 mt-0.5">Powered by {model.name}</p>
             </div>
           </div>
         )}
@@ -318,7 +318,7 @@ function ChatView({
                 className="flex justify-end"
               >
                 <div
-                  className="max-w-[78%] px-3 py-1.5 text-[10.5px] leading-snug rounded-xl rounded-br-sm text-gray-900"
+                  className="max-w-[78%] px-3 py-1.5 text-[14px] leading-snug rounded-xl rounded-br-sm text-gray-900"
                   style={{ backgroundColor: '#f1f3f5' }}
                 >
                   {msg.text}
@@ -342,7 +342,7 @@ function ChatView({
                   <Logo size={11} tone="on-dark" animate={false} />
                 </div>
                 <div
-                  className="px-3 py-1.5 text-[10.5px] leading-snug rounded-xl rounded-bl-sm text-white"
+                  className="px-3 py-1.5 text-[14px] leading-snug rounded-xl rounded-bl-sm text-white"
                   style={{ backgroundColor: BRAND_BLUE }}
                 >
                   {msg.text}
@@ -408,7 +408,7 @@ function ChatView({
               </div>
             ) : (
               <div
-                className="max-w-[80%] px-3 py-1.5 text-[10.5px] leading-snug rounded-xl rounded-bl-sm text-white"
+                className="max-w-[80%] px-3 py-1.5 text-[14px] leading-snug rounded-xl rounded-bl-sm text-white"
                 style={{ backgroundColor: BRAND_BLUE }}
               >
                 {aiInflight.text}
@@ -428,7 +428,7 @@ function ChatView({
 
       <div className="shrink-0 px-3 py-2 border-t border-gray-100 flex items-center gap-2">
         <Paperclip className="w-3.5 h-3.5 text-gray-400 shrink-0" strokeWidth={1.6} />
-        <div className="flex-1 bg-gray-50 rounded-full px-3 py-1.5 text-[10px] flex items-center min-h-6">
+        <div className="flex-1 bg-gray-50 rounded-full px-3 py-1.5 text-[14px] flex items-center min-h-6">
           {typedInput ? (
             <span className="text-gray-800">
               {typedInput}
@@ -475,10 +475,10 @@ function AgentView({
       <div className="shrink-0 flex items-center justify-between px-4 py-2.5 border-b border-gray-100">
         <div className="flex items-center gap-1.5">
           <Sparkles className="w-3.5 h-3.5" style={{ color: BRAND_BLUE }} strokeWidth={1.8} />
-          <p className="text-[11px] font-bold text-gray-900">Create new agent</p>
+          <p className="text-[15px] font-bold text-gray-900">Create new agent</p>
         </div>
         <div className="flex items-center gap-1 px-1.5 py-0.5 rounded-full" style={{ backgroundColor: `${BRAND_BLUE}10` }}>
-          <span className="text-[8px] font-semibold" style={{ color: BRAND_BLUE }}>Draft</span>
+          <span className="text-[16px] font-semibold" style={{ color: BRAND_BLUE }}>Draft</span>
         </div>
       </div>
 
@@ -503,8 +503,8 @@ function AgentView({
                 <Check className="w-7 h-7 text-white" strokeWidth={3} />
               </motion.div>
               <div className="text-center">
-                <p className="text-[12px] font-bold text-gray-900">Agent deployed</p>
-                <p className="text-[9.5px] text-gray-500 mt-0.5">
+                <p className="text-[16px] font-bold text-gray-900">Agent deployed</p>
+                <p className="text-[13px] text-gray-500 mt-0.5">
                   {AGENT.name} is now handling leads across {AGENT.channels.length} channels
                 </p>
               </div>
@@ -518,9 +518,9 @@ function AgentView({
               className="flex flex-col gap-2"
             >
               <div>
-                <p className="text-[8.5px] font-semibold text-gray-500 uppercase tracking-wider mb-1">Agent name</p>
+                <p className="text-[16px] font-semibold text-gray-500 uppercase tracking-wider mb-1">Agent name</p>
                 <div
-                  className="rounded-lg px-2.5 py-1.5 text-[10px] bg-white"
+                  className="rounded-lg px-2.5 py-1.5 text-[14px] bg-white"
                   style={{ border: `1px solid ${agentNameTyped ? `${BRAND_BLUE}40` : '#e5e7eb'}` }}
                 >
                   {agentNameTyped ? (
@@ -540,9 +540,9 @@ function AgentView({
               </div>
 
               <div>
-                <p className="text-[8.5px] font-semibold text-gray-500 uppercase tracking-wider mb-1">Role</p>
+                <p className="text-[16px] font-semibold text-gray-500 uppercase tracking-wider mb-1">Role</p>
                 <div
-                  className="rounded-lg px-2.5 py-1.5 text-[10px] bg-white flex items-center justify-between"
+                  className="rounded-lg px-2.5 py-1.5 text-[14px] bg-white flex items-center justify-between"
                   style={{ border: `1px solid ${agentRoleSelected ? `${BRAND_BLUE}40` : '#e5e7eb'}` }}
                 >
                   <span className={agentRoleSelected ? 'text-gray-900 font-medium' : 'text-gray-400'}>
@@ -553,9 +553,9 @@ function AgentView({
               </div>
 
               <div>
-                <p className="text-[8.5px] font-semibold text-gray-500 uppercase tracking-wider mb-1">Greeting</p>
+                <p className="text-[16px] font-semibold text-gray-500 uppercase tracking-wider mb-1">Greeting</p>
                 <div
-                  className="rounded-lg px-2.5 py-1.5 text-[10px] bg-white min-h-7"
+                  className="rounded-lg px-2.5 py-1.5 text-[14px] bg-white min-h-7"
                   style={{ border: `1px solid ${agentGreetingTyped ? `${BRAND_BLUE}40` : '#e5e7eb'}` }}
                 >
                   {agentGreetingTyped ? (
@@ -575,14 +575,14 @@ function AgentView({
               </div>
 
               <div>
-                <p className="text-[8.5px] font-semibold text-gray-500 uppercase tracking-wider mb-1">Channels</p>
+                <p className="text-[16px] font-semibold text-gray-500 uppercase tracking-wider mb-1">Channels</p>
                 <div className="flex gap-1.5 flex-wrap">
                   {AGENT.channels.map((ch, i) => {
                     const isChecked = agentChannelsChecked > i
                     return (
                       <div
                         key={ch}
-                        className="flex items-center gap-1 px-2 py-1 rounded-full text-[9.5px] transition-all"
+                        className="flex items-center gap-1 px-2 py-1 rounded-full text-[13px] transition-all"
                         style={{
                           backgroundColor: isChecked ? `${BRAND_BLUE}12` : '#f4f6fb',
                           border: `1px solid ${isChecked ? `${BRAND_BLUE}40` : '#e5e7eb'}`,
@@ -608,7 +608,7 @@ function AgentView({
 
               <div className="mt-1.5">
                 <div
-                  className="rounded-lg px-3 py-1.5 flex items-center justify-center gap-1.5 text-[10px] font-semibold text-white"
+                  className="rounded-lg px-3 py-1.5 flex items-center justify-center gap-1.5 text-[14px] font-semibold text-white"
                   style={{
                     background: `linear-gradient(135deg, ${BRAND_BLUE}, ${BRAND_BLUE}dd)`,
                     transform: agentSubmitPulse ? 'scale(1.02)' : 'scale(1)',


### PR DESCRIPTION
## Summary
Replaces the laptop and monitor mockups in the showcase with a unified browser mockup, adds an animated multi-color glow halo around every device, brightens the hero, and fixes a glyph-clipping bug in the How It Works step numbers.

## Showcase device upgrades
- **New `BrowserMockup`** (`components/sections/showcase/devices/BrowserMockup.jsx`) — macOS-style window with traffic-light dots + URL bar, no laptop base. Used by JotilSpace and JotilAvatar so both render at identical 820x560 canvases with consistent per-breakpoint scales (`0.38 / 0.5 / 0.7 / 0.78 / 0.5 / 0.68`).
- **New `DeviceGlow`** shared component — cyan → blue → purple → pink halo with two animated pulse layers (outer soft wash + tighter inner halo). Wired into Phone, Laptop, Monitor, and Browser mockups.
- `AvatarScreen` had its own inner browser chrome (tab + URL bar) that produced a browser-in-browser look once wrapped in BrowserMockup — removed.
- `SlideDevice` routes per-slug URLs into the mockup: space → `app.jotillabs.com`, avatar → `app.jotillabs.com/avatar`.
- Bumped text sizes inside `SpaceScreen` and `AvatarScreen` so labels stay legible after the transform-scale at lg/xl viewports.

## Hero
- Hero section now uses `bg-white` for a brighter, cleaner base (CogniDrift-inspired). The `BrandBackground` watermark still sits behind via fixed z-15.
- (Note for reviewers: an earlier "wrong-looking font" complaint during dev turned out to be a stale `.next` cache — no change in this PR, just `rm -rf .next` if it recurs.)

## How It Works
- Step numbers `01 / 02 / 03` had their top edge clipped because `leading-none` made the inline box exactly font-size tall, while JetBrains Mono numerals' actual glyph extends slightly above that. With `background-clip: text`, the gradient could only paint within the inline box, so the top of each glyph rendered transparent.
- Switched to `leading-[1.25]` + `pt-1` and bumped the gradient end stop from `<color>55` (~33% alpha) to `<color>aa` (~66% alpha) so the bottom-right is still soft but readable.

## Tooling
- Added `/d-*.png`, `/m-*.png`, `/t-*.png`, `/mobile-*.png` patterns to `.gitignore` so ad-hoc Playwright audit screenshots stop landing in commits (this happened in #108 — none in this PR).

## Test plan
- [ ] Homepage at 1280: JotilSpace + JotilAvatar render in a clean browser frame (no laptop base, no nested chrome). Glow halo is visible and pulses.
- [ ] Inside the browser frames, model selector "Claude 4.7", chart bars (Voice/Email/Web/SMS), Sarah Chen card, and the avatar chat are all readable.
- [ ] Hero is white, headline uses Montserrat Alternates, voice orb on right.
- [ ] How It Works numbers `01 / 02 / 03` are fully visible from top to bottom, no clipping.
- [ ] At 768 / 375 the showcase devices fit the viewport — no horizontal overflow on `/`.
