### PR TITLE
Watermark stacking + softer device glow

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -761,23 +761,23 @@ textarea:focus-visible {
    Inspired by the CogniDrift mockup: subtle outer bloom + tighter inner halo. */
 @keyframes device-glow-pulse-outer {
   0%, 100% {
-    opacity: 0.45;
+    opacity: 0.25;
     transform: scale(1);
   }
   50% {
-    opacity: 0.75;
-    transform: scale(1.04);
+    opacity: 0.42;
+    transform: scale(1.03);
   }
 }
 
 @keyframes device-glow-pulse-inner {
   0%, 100% {
-    opacity: 0.25;
+    opacity: 0.13;
     transform: scale(1);
   }
   50% {
-    opacity: 0.5;
-    transform: scale(1.03);
+    opacity: 0.26;
+    transform: scale(1.02);
   }
 }
 
@@ -802,6 +802,9 @@ textarea:focus-visible {
   margin-inline: auto;
   width: calc(var(--w) * var(--s));
   height: calc(var(--h) * var(--s));
+  /* Stack devices ABOVE the homepage watermark (which sits at z-1 inside
+     <main>) so opaque device screens cover the watermark. */
+  z-index: 2;
 }
 
 [data-device-frame] > .device-inner {

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -6,6 +6,7 @@ import { Stats } from '@/components/sections/Stats'
 import { Testimonials } from '@/components/sections/Testimonials'
 import { IntegrationStrip } from '@/components/sections/IntegrationStrip'
 import { CTASection } from '@/components/sections/CTASection'
+import { HomeWatermark } from '@/components/design/HomeWatermark'
 
 export const metadata = {
   title: 'JotilLabs - AI Voice, Chat & Automation Platform',
@@ -16,6 +17,7 @@ export const metadata = {
 export default function Home() {
   return (
     <>
+      <HomeWatermark />
       <Hero />
       {/* <LogoCloud /> */}
       <ScrollProductShowcase />

--- a/components/design/BrandBackground.jsx
+++ b/components/design/BrandBackground.jsx
@@ -1,59 +1,8 @@
 'use client'
 
-import { useEffect, useRef } from 'react'
-import Logo from '@/components/ui/Logo'
-
 const NOISE_SVG = `data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix values='0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0.4 0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E`
 
 export function BrandBackground({ variant = 'quiet' }) {
-  const watermarkRef = useRef(null)
-
-  useEffect(() => {
-    if (variant !== 'hero') return
-    if (typeof window === 'undefined') return
-
-    const fine = window.matchMedia('(pointer: fine)').matches
-    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    if (!fine || reduced) return
-
-    let mouseX = 0.5
-    let mouseY = 0.5
-    let currentX = 0.5
-    let currentY = 0.5
-    let rafId = 0
-
-    const onMouseMove = (e) => {
-      mouseX = e.clientX / window.innerWidth
-      mouseY = e.clientY / window.innerHeight
-      if (!rafId) rafId = requestAnimationFrame(update)
-    }
-
-    const update = () => {
-      rafId = 0
-      currentX += (mouseX - currentX) * 0.08
-      currentY += (mouseY - currentY) * 0.08
-
-      const tiltX = (currentY - 0.5) * -14
-      const tiltY = (currentX - 0.5) * 18
-      if (watermarkRef.current) {
-        watermarkRef.current.style.transform = `perspective(1100px) translateX(15%) rotateX(${tiltX}deg) rotateY(${tiltY}deg)`
-      }
-
-      if (
-        Math.abs(mouseX - currentX) > 0.002 ||
-        Math.abs(mouseY - currentY) > 0.002
-      ) {
-        rafId = requestAnimationFrame(update)
-      }
-    }
-
-    window.addEventListener('mousemove', onMouseMove, { passive: true })
-    return () => {
-      window.removeEventListener('mousemove', onMouseMove)
-      if (rafId) cancelAnimationFrame(rafId)
-    }
-  }, [variant])
-
   const isHero = variant === 'hero'
 
   return (
@@ -112,28 +61,6 @@ export function BrandBackground({ variant = 'quiet' }) {
           }}
         />
       </div>
-
-      {/* Watermark — fixed at z-[15], above section bgs (main z-10) but below navbar (z-50).
-          Static across the full home page during scroll. Homepage only. */}
-      {isHero && (
-        <div
-          aria-hidden="true"
-          className="pointer-events-none fixed inset-0 z-15 hidden md:flex items-center justify-end overflow-hidden"
-        >
-          <div
-            ref={watermarkRef}
-            className="will-change-transform mr-8 lg:mr-16"
-            style={{
-              opacity: 0.06,
-              transform: 'translateX(15%)',
-              transition: 'transform 0.6s cubic-bezier(0.22, 1, 0.36, 1)',
-              transformStyle: 'preserve-3d',
-            }}
-          >
-            <Logo size={700} tone="brand" animate={false} />
-          </div>
-        </div>
-      )}
     </>
   )
 }

--- a/components/design/HomeWatermark.jsx
+++ b/components/design/HomeWatermark.jsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import Logo from '@/components/ui/Logo'
+
+/**
+ * Site watermark for the homepage. Fixed positioning, sits at z-1 INSIDE
+ * <main> (so it stacks below opaque device mockups which carry their own
+ * higher z-index inside the same context, but above section backgrounds and
+ * inline content). Subtle cursor-driven 3D parallax on fine pointers.
+ *
+ * Render as a child of <main> on the homepage only. Hidden below md breakpoint.
+ */
+export function HomeWatermark() {
+  const ref = useRef(null)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const fine = window.matchMedia('(pointer: fine)').matches
+    const reduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (!fine || reduced) return
+
+    let mouseX = 0.5
+    let mouseY = 0.5
+    let currentX = 0.5
+    let currentY = 0.5
+    let rafId = 0
+
+    const onMouseMove = (e) => {
+      mouseX = e.clientX / window.innerWidth
+      mouseY = e.clientY / window.innerHeight
+      if (!rafId) rafId = requestAnimationFrame(update)
+    }
+
+    const update = () => {
+      rafId = 0
+      currentX += (mouseX - currentX) * 0.08
+      currentY += (mouseY - currentY) * 0.08
+
+      const tiltX = (currentY - 0.5) * -14
+      const tiltY = (currentX - 0.5) * 18
+      if (ref.current) {
+        ref.current.style.transform = `perspective(1100px) translateX(28%) rotateX(${tiltX}deg) rotateY(${tiltY}deg)`
+      }
+
+      if (
+        Math.abs(mouseX - currentX) > 0.002 ||
+        Math.abs(mouseY - currentY) > 0.002
+      ) {
+        rafId = requestAnimationFrame(update)
+      }
+    }
+
+    window.addEventListener('mousemove', onMouseMove, { passive: true })
+    return () => {
+      window.removeEventListener('mousemove', onMouseMove)
+      if (rafId) cancelAnimationFrame(rafId)
+    }
+  }, [])
+
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none fixed inset-0 z-[1] hidden md:flex items-center justify-end overflow-hidden"
+    >
+      <div
+        ref={ref}
+        className="will-change-transform -mr-12 lg:-mr-20"
+        style={{
+          opacity: 0.06,
+          transform: 'translateX(28%)',
+          transition: 'transform 0.6s cubic-bezier(0.22, 1, 0.36, 1)',
+          transformStyle: 'preserve-3d',
+        }}
+      >
+        <Logo size={900} tone="brand" animate={false} />
+      </div>
+    </div>
+  )
+}

--- a/components/sections/showcase/devices/DeviceGlow.jsx
+++ b/components/sections/showcase/devices/DeviceGlow.jsx
@@ -10,9 +10,9 @@ export function DeviceGlow({ radius = 60, inset = -18, intensity = 1 }) {
           inset,
           borderRadius: radius,
           background:
-            'linear-gradient(135deg, rgba(6,182,212,0.55), rgba(59,130,246,0.55), rgba(139,92,246,0.6), rgba(217,70,239,0.55))',
-          filter: 'blur(36px)',
-          opacity: 0.55 * intensity,
+            'linear-gradient(135deg, rgba(6,182,212,0.5), rgba(59,130,246,0.5), rgba(139,92,246,0.55), rgba(217,70,239,0.5))',
+          filter: 'blur(40px)',
+          opacity: 0.32 * intensity,
         }}
       />
       {/* Inner halo — tighter, sharper colour */}
@@ -24,9 +24,9 @@ export function DeviceGlow({ radius = 60, inset = -18, intensity = 1 }) {
           inset: typeof inset === 'number' ? inset + 8 : inset,
           borderRadius: radius,
           background:
-            'linear-gradient(135deg, rgba(6,182,212,0.7), rgba(139,92,246,0.7), rgba(217,70,239,0.6))',
-          filter: 'blur(14px)',
-          opacity: 0.35 * intensity,
+            'linear-gradient(135deg, rgba(6,182,212,0.6), rgba(139,92,246,0.6), rgba(217,70,239,0.5))',
+          filter: 'blur(16px)',
+          opacity: 0.18 * intensity,
         }}
       />
     </>


### PR DESCRIPTION
## Summary
Two related polish items on the homepage:

1. The JotilLabs watermark used to bleed through phone/browser screens (visible hexagon "behind" the chat bubbles). Restacked it so opaque device screens cover the watermark while it still shows everywhere else on the homepage.
2. The multi-color glow halo around devices was too prominent. Toned down to roughly 40–45% softer so the mockup stays the focal point.

## Watermark stacking
**Before:** Watermark rendered as `position: fixed; z-index: 15` directly inside `BrandBackground`, which sits OUTSIDE `<main>` (z-10). Even at 6% opacity, painting on top of a pure-white phone screen produced a visible blue tint that read as "phone is transparent".

**After:**
- Lifted the watermark JSX + cursor parallax into a new `components/design/HomeWatermark.jsx` client component.
- Rendered as the first child of `<main>` from `app/page.jsx` (homepage only).
- The watermark is `position: fixed; z-index: 1`, but because it now lives inside `<main>` (which has `z-10` and creates a stacking context), it stacks at z-11 absolute — above section backgrounds (z-auto) but below…
- `[data-device-frame]` in `app/globals.css` got `z-index: 2`. Devices stack at z-12 absolute → opaque `bg-white` screens cover the watermark.
- Net: watermark visible across the entire homepage (hero + showcase + everything else), but never inside a device screen.

## Glow halo tone-down
`components/sections/showcase/devices/DeviceGlow.jsx`:
- Outer wash opacity: `0.55 → 0.32`, blur radius `36px → 40px`, gradient stops slightly lower alpha.
- Inner halo opacity: `0.35 → 0.18`, blur radius `14px → 16px`.

`app/globals.css` keyframes:
- `device-glow-pulse-outer`: `0.45–0.75` → `0.25–0.42`, scale `1.04 → 1.03`.
- `device-glow-pulse-inner`: `0.25–0.5` → `0.13–0.26`, scale `1.03 → 1.02`.

The halo still reads as a soft cyan→purple→pink accent but doesn't compete with the device content.

## Dependency note
This branch is based on `feat/browser-mockup-and-polish` (PR #109). It needs #109 to merge first; once that lands, this PR will become a clean diff against `main` (no rebase needed since both targeting `main`).

## Test plan
- [ ] Homepage hero: watermark visible at the right edge, behind the voice orb.
- [ ] JotilReceptionist phone (and other phones): screen is solid white, no blue tint, no hexagon shape visible inside the screen.
- [ ] JotilSpace + JotilAvatar browser frames: same — solid screen content, no bleed-through, glow halo softer than before.
- [ ] Watermark still visible in the gaps around phones / between the device and the section edge.
- [ ] At 375 / 768: no overflow regressions; watermark hidden on mobile (`hidden md:flex`).
